### PR TITLE
feat: tuning + autoscaling

### DIFF
--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -79,11 +79,11 @@ microservice-chart:
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
-    - type: cpu
-      metadata:
+     - type: cpu
+       metadata:
         # Required
-        type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
-        value: "80"
+         type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
+         value: "70"
   envConfig:
     MONGO_HOST: pagopa-u-weu-ecommerce-cosmos-account.mongo.cosmos.azure.com
     MONGO_USERNAME: pagopa-u-weu-ecommerce-cosmos-account


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Reduced KEDA CPU triggering to 70%.
<!--- Describe your changes in detail -->

#### Motivation and Context
Since POD CPU limit was lowered to 200, the total container CPU limit is 250 (200 + 50 for crt-mounter) so when payment-methods CPU consumption is 100% the total container CPU consumption is exactly 80%, causing the trigger to not be enabled. Lowering the trigger threshold the scaling is performed correctly.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Test performed executing soak tests in UAT environment verifying that, for CPU usage above 70% the scaling is correctly performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.