### PR TITLE
fix: restore get payment methods array response body

### DIFF
--- a/api-spec/api.yaml
+++ b/api-spec/api.yaml
@@ -62,7 +62,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaymentMethodsResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/PaymentMethodResponse'
         '500':
           description: Service unavailable
           content:

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -64,42 +64,39 @@ public class PaymentMethodsController implements PaymentMethodsApi {
     }
 
     @Override
-    public Mono<ResponseEntity<PaymentMethodsResponseDto>> getAllPaymentMethods(
-                                                                                BigDecimal amount,
-                                                                                ServerWebExchange exchange
+    public Mono<ResponseEntity<Flux<PaymentMethodResponseDto>>> getAllPaymentMethods(
+                                                                                     BigDecimal amount,
+                                                                                     ServerWebExchange exchange
     ) {
-        return paymentMethodService.retrievePaymentMethods(amount != null ? amount.intValue() : null)
-                .map(paymentMethod -> {
-                    PaymentMethodResponseDto responseDto = new PaymentMethodResponseDto();
-                    responseDto.setId(paymentMethod.getPaymentMethodID().value().toString());
-                    responseDto.setName(paymentMethod.getPaymentMethodName().value());
-                    responseDto.setDescription(paymentMethod.getPaymentMethodDescription().value());
-                    responseDto.setStatus(
-                            PaymentMethodStatusDto
-                                    .valueOf(paymentMethod.getPaymentMethodStatus().value().toString())
-                    );
-                    responseDto.setRanges(
-                            paymentMethod.getPaymentMethodRanges().stream().map(
-                                    r -> {
-                                        RangeDto rangeDto = new RangeDto();
-                                        rangeDto.setMin(r.min());
-                                        rangeDto.setMax(r.max());
-                                        return rangeDto;
-                                    }
-                            ).toList()
-                    );
-                    responseDto.setPaymentTypeCode(paymentMethod.getPaymentMethodTypeCode().value());
-                    responseDto.setAsset(paymentMethod.getPaymentMethodAsset().value());
+        return Mono.just(
+                ResponseEntity.ok(
+                        paymentMethodService.retrievePaymentMethods(amount != null ? amount.intValue() : null)
+                                .map(paymentMethod -> {
+                                    PaymentMethodResponseDto responseDto = new PaymentMethodResponseDto();
+                                    responseDto.setId(paymentMethod.getPaymentMethodID().value().toString());
+                                    responseDto.setName(paymentMethod.getPaymentMethodName().value());
+                                    responseDto.setDescription(paymentMethod.getPaymentMethodDescription().value());
+                                    responseDto.setStatus(
+                                            PaymentMethodStatusDto
+                                                    .valueOf(paymentMethod.getPaymentMethodStatus().value().toString())
+                                    );
+                                    responseDto.setRanges(
+                                            paymentMethod.getPaymentMethodRanges().stream().map(
+                                                    r -> {
+                                                        RangeDto rangeDto = new RangeDto();
+                                                        rangeDto.setMin(r.min());
+                                                        rangeDto.setMax(r.max());
+                                                        return rangeDto;
+                                                    }
+                                            ).collect(Collectors.toList())
+                                    );
+                                    responseDto.setPaymentTypeCode(paymentMethod.getPaymentMethodTypeCode().value());
+                                    responseDto.setAsset(paymentMethod.getPaymentMethodAsset().value());
 
-                    return responseDto;
-                })
-                .collectList()
-                .map(
-                        paymentMethods -> ResponseEntity.ok(
-                                new PaymentMethodsResponseDto()
-                                        .paymentMethods(paymentMethods)
-                        )
-                );
+                                    return responseDto;
+                                })
+                )
+        );
     }
 
     @Override

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -74,7 +74,7 @@ class PaymentMethodsControllerTests {
                 Flux.just(paymentMethod)
         );
 
-        PaymentMethodsResponseDto expectedResult = TestUtil.getPaymentMethodsResponse(paymentMethod);
+        PaymentMethodResponseDto expectedResult = TestUtil.getPaymentMethodResponse(paymentMethod);
 
         webClient
                 .get()
@@ -87,7 +87,7 @@ class PaymentMethodsControllerTests {
                 .exchange()
                 .expectStatus()
                 .isOk()
-                .expectBodyList(PaymentMethodsResponseDto.class)
+                .expectBodyList(PaymentMethodResponseDto.class)
                 .hasSize(1)
                 .contains(expectedResult);
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Restore GET `payment-methods` method response to return payment methods array as top object
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to support the old checkout f.e. implementation.
Those modification can be reverted with https://github.com/pagopa/pagopa-ecommerce-payment-methods-service/pull/45 that can be merged once Checkout f.e. will be upgraded into UAT environment
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.