### PR TITLE
[CHK 2096] feat: generate unique orderId with prefix and cache check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<jacoco.version>0.8.8</jacoco.version>
 		<spotless.version>2.28.0</spotless.version>
 		<ecs-logging-version>1.5.0</ecs-logging-version>
-		<pagopa-ecommerce-commons.version>0.27.0</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>0.28.0</pagopa-ecommerce-commons.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -230,8 +230,6 @@
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
 					<scmVersionType>branch</scmVersionType>
-					<scmVersion>CHK-2095-NX-redisTemplateWrapper</scmVersion>
-					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,8 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+					<scmVersion>CHK-2095-NX-redisTemplateWrapper</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
-					<scmVersionType>branch</scmVersionType>
+					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -279,7 +279,6 @@ public class PaymentMethodService {
                     URI resultUrl = returnUrlBasePath.resolve(sessionUrlConfig.outcomeSuffix());
                     URI merchantUrl = returnUrlBasePath;
                     URI cancelUrl = returnUrlBasePath.resolve(sessionUrlConfig.cancelSuffix());
-                    String customerId = UUID.randomUUID().toString().replace("-", "").substring(0, 15);
                     URI notificationUrl = UriComponentsBuilder
                             .fromHttpUrl(sessionUrlConfig.notificationUrl())
                             .build(
@@ -298,7 +297,7 @@ public class PaymentMethodService {
                             notificationUrl, // notificationUrl
                             cancelUrl, // cancelUrl
                             orderId, // orderId
-                            customerId, // customerId
+                            null, // customerId
                             paymentMethod, // paymentMethod
                             npgDefaultApiKey // defaultApiKey
                     ).map(form -> Tuples.of(form, sessionPaymentMethod, orderId));

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.payment.methods.application;
 
+import io.vavr.Tuple;
 import it.pagopa.ecommerce.commons.client.NpgClient;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.generated.npg.v1.dto.FieldsDto;
@@ -261,11 +262,16 @@ public class PaymentMethodService {
     public Mono<CreateSessionResponseDto> createSessionForPaymentMethod(
                                                                         String id
     ) {
-        String orderId = uniqueIdUtils.generateUniqueId();
         return paymentMethodRepository.findById(id)
                 .map(PaymentMethodDocument::getPaymentMethodName)
                 .map(NpgClient.PaymentMethod::fromServiceName)
-                .flatMap(paymentMethod -> {
+                .flatMap(
+                        paymentMethod -> uniqueIdUtils.generateUniqueId()
+                                .map(orderId -> Tuples.of(orderId, paymentMethod))
+                )
+                .flatMap(data -> {
+                    NpgClient.PaymentMethod paymentMethod = data.getT2();
+                    String orderId = data.getT1();
                     SessionPaymentMethod sessionPaymentMethod = SessionPaymentMethod
                             .fromValue(paymentMethod.serviceName);
                     URI returnUrlBasePath = sessionUrlConfig.basePath();
@@ -295,10 +301,10 @@ public class PaymentMethodService {
                             customerId, // customerId
                             paymentMethod, // paymentMethod
                             npgDefaultApiKey // defaultApiKey
-                    ).map(form -> Tuples.of(form, sessionPaymentMethod));
+                    ).map(form -> Tuples.of(form, sessionPaymentMethod, orderId));
                 }).map(data -> {
                     FieldsDto fields = data.getT1();
-
+                    String orderId = data.getT3();
                     npgSessionsTemplateWrapper
                             .save(
                                     new NpgSessionDocument(
@@ -313,7 +319,7 @@ public class PaymentMethodService {
                 }).map(data -> {
                     FieldsDto fields = data.getT1();
                     SessionPaymentMethod paymentMethod = data.getT2();
-
+                    String orderId = data.getT3();
                     return new CreateSessionResponseDto()
                             .orderId(orderId)
                             .paymentMethodData(

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/config/RedisConfig.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/config/RedisConfig.java
@@ -2,6 +2,8 @@ package it.pagopa.ecommerce.payment.methods.config;
 
 import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionDocument;
 import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionsTemplateWrapper;
+import it.pagopa.ecommerce.payment.methods.infrastructure.UniqueIdDocument;
+import it.pagopa.ecommerce.payment.methods.infrastructure.UniqueIdTemplateWrapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,6 +35,27 @@ public class RedisConfig {
                 redisTemplate,
                 "npg",
                 Duration.ofSeconds(sessionsTtl)
+        );
+    }
+
+    @Bean
+    public UniqueIdTemplateWrapper uniqueIdTemplateWrapper(
+                                                           RedisConnectionFactory redisConnectionFactory
+    ) {
+        RedisTemplate<String, UniqueIdDocument> redisTemplate = new RedisTemplate<>();
+        Jackson2JsonRedisSerializer<UniqueIdDocument> jacksonRedisSerializer = new Jackson2JsonRedisSerializer<>(
+                UniqueIdDocument.class
+        );
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(jacksonRedisSerializer);
+        redisTemplate.afterPropertiesSet();
+
+        return new UniqueIdTemplateWrapper(
+                redisTemplate,
+                "keys",
+                Duration.ofSeconds(60)
         );
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/config/RedisConfig.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/config/RedisConfig.java
@@ -54,7 +54,7 @@ public class RedisConfig {
 
         return new UniqueIdTemplateWrapper(
                 redisTemplate,
-                "keys",
+                "uniqueId",
                 Duration.ofSeconds(60)
         );
     }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -34,6 +34,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                 PaymentMethodAlreadyInUseException.class,
                 PaymentMethodNotFoundException.class,
                 OrderIdNotFoundException.class,
+                UniqueIdGenerationException.class,
                 AfmResponseException.class,
                 InvalidSessionException.class,
                 MismatchedSecurityTokenException.class,
@@ -64,6 +65,11 @@ public class PaymentMethodsController implements PaymentMethodsApi {
             return new ResponseEntity<>(
                     new ProblemJsonDto().status(404).title(notFoundTitle).detail("Order id not found"),
                     HttpStatus.NOT_FOUND
+            );
+        } else if (exception instanceof UniqueIdGenerationException) {
+            return new ResponseEntity<>(
+                    new ProblemJsonDto().status(409).title("Internal system error").detail(exception.getMessage()),
+                    HttpStatus.CONFLICT
             );
         } else if (exception instanceof MismatchedSecurityTokenException) {
             return new ResponseEntity<>(

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -68,8 +68,8 @@ public class PaymentMethodsController implements PaymentMethodsApi {
             );
         } else if (exception instanceof UniqueIdGenerationException) {
             return new ResponseEntity<>(
-                    new ProblemJsonDto().status(409).title("Internal system error").detail(exception.getMessage()),
-                    HttpStatus.CONFLICT
+                    new ProblemJsonDto().status(500).title("Internal system error").detail(exception.getMessage()),
+                    HttpStatus.INTERNAL_SERVER_ERROR
             );
         } else if (exception instanceof MismatchedSecurityTokenException) {
             return new ResponseEntity<>(

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/exception/UniqueIdGenerationException.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/exception/UniqueIdGenerationException.java
@@ -1,0 +1,9 @@
+package it.pagopa.ecommerce.payment.methods.exception;
+
+public class UniqueIdGenerationException extends RuntimeException {
+    public UniqueIdGenerationException() {
+        super(
+                "Error when generating unique id"
+        );
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdDocument.java
@@ -1,24 +1,8 @@
 package it.pagopa.ecommerce.payment.methods.infrastructure;
 
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.PersistenceConstructor;
-import org.springframework.data.redis.core.RedisHash;
 import org.springframework.lang.NonNull;
 
-@RedisHash(value = "keys")
 public record UniqueIdDocument(@NonNull @Id String id) {
-    /*
-     * @formatter:off
-     *
-     * Warning java:S6207 - Redundant constructors/methods should be avoided in records
-     * Suppressed because this constructor is just to add the `@PersistenceConstructor` annotation
-     * and is currently the canonical way to add annotations to record constructors
-     *
-     * @formatter:on
-     */
-    @SuppressWarnings("java:S6207")
-    @PersistenceConstructor
-    public UniqueIdDocument {
-        // Do nothing
-    }
+
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdDocument.java
@@ -1,0 +1,24 @@
+package it.pagopa.ecommerce.payment.methods.infrastructure;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.lang.NonNull;
+
+@RedisHash(value = "keys")
+public record UniqueIdDocument(@NonNull @Id String id) {
+    /*
+     * @formatter:off
+     *
+     * Warning java:S6207 - Redundant constructors/methods should be avoided in records
+     * Suppressed because this constructor is just to add the `@PersistenceConstructor` annotation
+     * and is currently the canonical way to add annotations to record constructors
+     *
+     * @formatter:on
+     */
+    @SuppressWarnings("java:S6207")
+    @PersistenceConstructor
+    public UniqueIdDocument {
+        // Do nothing
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdDocument.java
@@ -3,6 +3,14 @@ package it.pagopa.ecommerce.payment.methods.infrastructure;
 import org.springframework.data.annotation.Id;
 import org.springframework.lang.NonNull;
 
-public record UniqueIdDocument(@NonNull @Id String id) {
+import java.time.OffsetDateTime;
 
+public record UniqueIdDocument(
+        @NonNull @Id String id,
+        String creationDate
+) {
+
+    public UniqueIdDocument(String id) {
+        this(id, OffsetDateTime.now().toString());
+    }
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdTemplateWrapper.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/UniqueIdTemplateWrapper.java
@@ -1,0 +1,28 @@
+package it.pagopa.ecommerce.payment.methods.infrastructure;
+
+import it.pagopa.ecommerce.commons.redis.templatewrappers.RedisTemplateWrapper;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.Duration;
+
+public class UniqueIdTemplateWrapper extends RedisTemplateWrapper<UniqueIdDocument> {
+    /**
+     * Primary constructor
+     *
+     * @param redisTemplate inner redis template
+     * @param keyspace      keyspace associated to this wrapper
+     * @param ttl           time to live for keys
+     */
+    public UniqueIdTemplateWrapper(
+            RedisTemplate<String, UniqueIdDocument> redisTemplate,
+            String keyspace,
+            Duration ttl
+    ) {
+        super(redisTemplate, keyspace, ttl);
+    }
+
+    @Override
+    protected String getKeyFromEntity(UniqueIdDocument value) {
+        return value.id();
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
@@ -17,6 +17,7 @@ public class UniqueIdUtils {
     private static final String ALPHANUMERICS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._";
     private static final int MAX_LENGTH = 18;
     private static final int MAX_NUMBER_ATTEMPTS = 3;
+    private static final String PRODUCT_PREFIX = "E";
 
     @Autowired
     public UniqueIdUtils(UniqueIdTemplateWrapper uniqueIdTemplateWrapper) {
@@ -39,9 +40,10 @@ public class UniqueIdUtils {
     }
 
     private static String generateRandomIdentifier() {
-        String timestampToString = String.valueOf(System.currentTimeMillis());
-        int randomStringLength = MAX_LENGTH - timestampToString.length();
-        return timestampToString + generateRandomString(randomStringLength);
+        StringBuilder uniqueId = new StringBuilder(PRODUCT_PREFIX);
+        uniqueId.append(System.currentTimeMillis());
+        int randomStringLength = MAX_LENGTH - uniqueId.length();
+        return uniqueId.append(generateRandomString(randomStringLength)).toString();
     }
 
     private static String generateRandomString(int length) {

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
@@ -35,7 +35,7 @@ public class UniqueIdUtils {
                 uniqueId = generateRandomIdentifier();
             }
         }
-        return isSuccessfullySaved ? Mono.error(new UniqueIdGenerationException()) : Mono.just(uniqueId);
+        return !isSuccessfullySaved ? Mono.error(new UniqueIdGenerationException()) : Mono.just(uniqueId);
     }
 
     private static String generateRandomIdentifier() {

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
@@ -26,12 +26,12 @@ public class UniqueIdUtils {
 
     public Mono<String> generateUniqueId() {
         boolean isSuccessfullySaved = false;
-        int index = 0;
+        int attempt = 0;
         String uniqueId = generateRandomIdentifier();
-        while (index <= MAX_NUMBER_ATTEMPTS && !isSuccessfullySaved) {
+        while (attempt < MAX_NUMBER_ATTEMPTS && !isSuccessfullySaved) {
             isSuccessfullySaved = uniqueIdTemplateWrapper
                     .saveIfAbsent(new UniqueIdDocument(uniqueId), Duration.ofSeconds(60));
-            index++;
+            attempt++;
             if (!isSuccessfullySaved) {
                 uniqueId = generateRandomIdentifier();
             }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtils.java
@@ -1,16 +1,44 @@
 package it.pagopa.ecommerce.payment.methods.utils;
 
+import it.pagopa.ecommerce.payment.methods.exception.UniqueIdGenerationException;
+import it.pagopa.ecommerce.payment.methods.infrastructure.UniqueIdDocument;
+import it.pagopa.ecommerce.payment.methods.infrastructure.UniqueIdTemplateWrapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 import java.security.SecureRandom;
+import java.time.Duration;
 
 @Component
 public class UniqueIdUtils {
+    private final UniqueIdTemplateWrapper uniqueIdTemplateWrapper;
     private static final SecureRandom secureRandom = new SecureRandom();
     private static final String ALPHANUMERICS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._";
     private static final int MAX_LENGTH = 18;
+    private static final int MAX_NUMBER_ATTEMPTS = 3;
 
-    public String generateUniqueId() {
+    @Autowired
+    public UniqueIdUtils(UniqueIdTemplateWrapper uniqueIdTemplateWrapper) {
+        this.uniqueIdTemplateWrapper = uniqueIdTemplateWrapper;
+    }
+
+    public Mono<String> generateUniqueId() {
+        boolean isSuccessfullySaved = false;
+        int index = 0;
+        String uniqueId = generateRandomIdentifier();
+        while (index <= MAX_NUMBER_ATTEMPTS && !isSuccessfullySaved) {
+            isSuccessfullySaved = uniqueIdTemplateWrapper
+                    .saveIfAbsent(new UniqueIdDocument(uniqueId), Duration.ofSeconds(60));
+            index++;
+            if (!isSuccessfullySaved) {
+                uniqueId = generateRandomIdentifier();
+            }
+        }
+        return isSuccessfullySaved ? Mono.error(new UniqueIdGenerationException()) : Mono.just(uniqueId);
+    }
+
+    private static String generateRandomIdentifier() {
         String timestampToString = String.valueOf(System.currentTimeMillis());
         int randomStringLength = MAX_LENGTH - timestampToString.length();
         return timestampToString + generateRandomString(randomStringLength);

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -247,7 +247,7 @@ class PaymentMethodsControllerTests {
     void shouldReturnResponseUniqueId() {
         ResponseEntity<ProblemJsonDto> responseEntity = paymentMethodsController
                 .errorHandler(new UniqueIdGenerationException());
-        assertEquals(HttpStatus.CONFLICT, responseEntity.getStatusCode());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
         assertEquals("Internal system error", responseEntity.getBody().getTitle());
         assertEquals("Error when generating unique id", responseEntity.getBody().getDetail());
     }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -23,7 +23,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -203,7 +202,6 @@ class PaymentMethodsControllerTests {
         CreateSessionResponseDto responseDto = TestUtil.createSessionResponseDto(paymentMethodId);
         Mockito.when(paymentMethodService.createSessionForPaymentMethod(any()))
                 .thenReturn(Mono.just(responseDto));
-        Hooks.onOperatorDebug();
         webClient
                 .post()
                 .uri("/payment-methods/" + paymentMethodId + "/sessions")

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
@@ -317,7 +317,7 @@ class PaymentMethodServiceTests {
         FieldsDto npgResponse = TestUtil.npgResponse();
         String orderId = UUID.randomUUID().toString().replace("-", "").substring(0, 15);
 
-        Mockito.when(uniqueIdUtils.generateUniqueId()).thenReturn(orderId);
+        Mockito.when(uniqueIdUtils.generateUniqueId()).thenReturn(Mono.just(orderId));
         Mockito.when(paymentMethodRepository.findById(paymentMethodId)).thenReturn(Mono.just(paymentMethodDocument));
         Mockito.when(npgClient.buildForm(any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -21,6 +21,7 @@ import it.pagopa.generated.ecommerce.gec.v1.dto.PspSearchCriteriaDto;
 import org.springframework.data.util.Pair;
 
 import java.math.BigInteger;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -305,5 +306,22 @@ public class TestUtil {
                 document.cardData(),
                 newTransactionId
         );
+    }
+
+    public static CreateSessionResponseDto createSessionResponseDto(String paymentMethodId) {
+        return new CreateSessionResponseDto()
+                .orderId("orderId")
+                .paymentMethodData(
+                        new CardFormFieldsDto().paymentMethod(paymentMethodId).form(
+                                List.of(
+                                        new it.pagopa.ecommerce.payment.methods.server.model.FieldDto()
+                                                .type("TEXT")
+
+                                                .id("CARD_NUMBER")
+                                                .src(URI.create("http://localhost")).propertyClass("CARD_FIELD")
+                                )
+                        )
+                );
+
     }
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtilsTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtilsTests.java
@@ -21,6 +21,7 @@ class UniqueIdUtilsTests {
         StepVerifier.create(uniqueIdUtils.generateUniqueId())
                 .expectErrorMatches(e -> e instanceof UniqueIdGenerationException)
                 .verify();
+        Mockito.verify(uniqueIdTemplateWrapper, Mockito.times(3)).saveIfAbsent(any(), any());
     }
 
     @Test
@@ -31,6 +32,7 @@ class UniqueIdUtilsTests {
                         response -> response.length() == 18 && response.startsWith(PRODUCT_PREFIX)
                 )
                 .verifyComplete();
+        Mockito.verify(uniqueIdTemplateWrapper, Mockito.times(3)).saveIfAbsent(any(), any());
     }
 
     @Test
@@ -41,5 +43,6 @@ class UniqueIdUtilsTests {
                         response -> response.length() == 18 && response.startsWith(PRODUCT_PREFIX)
                 )
                 .verifyComplete();
+        Mockito.verify(uniqueIdTemplateWrapper, Mockito.times(1)).saveIfAbsent(any(), any());
     }
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtilsTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtilsTests.java
@@ -5,9 +5,4 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class UniqueIdUtilsTests {
 
-    @Test
-    void generateUniqueIdCorrectly() {
-        String uniqueId = new UniqueIdUtils().generateUniqueId();
-        assertEquals(uniqueId.length(), 18);
-    }
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtilsTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/UniqueIdUtilsTests.java
@@ -13,6 +13,8 @@ class UniqueIdUtilsTests {
 
     private final UniqueIdUtils uniqueIdUtils = new UniqueIdUtils(uniqueIdTemplateWrapper);
 
+    private static final String PRODUCT_PREFIX = "E";
+
     @Test
     void shouldGenerateUniqueIdGenerateException() {
         Mockito.when(uniqueIdTemplateWrapper.saveIfAbsent(any(), any())).thenReturn(false);
@@ -26,7 +28,7 @@ class UniqueIdUtilsTests {
         Mockito.when(uniqueIdTemplateWrapper.saveIfAbsent(any(), any())).thenReturn(false, false, true);
         StepVerifier.create(uniqueIdUtils.generateUniqueId())
                 .expectNextMatches(
-                        response -> response.length() == 18
+                        response -> response.length() == 18 && response.startsWith(PRODUCT_PREFIX)
                 )
                 .verifyComplete();
     }
@@ -36,7 +38,7 @@ class UniqueIdUtilsTests {
         Mockito.when(uniqueIdTemplateWrapper.saveIfAbsent(any(), any())).thenReturn(true);
         StepVerifier.create(uniqueIdUtils.generateUniqueId())
                 .expectNextMatches(
-                        response -> response.length() == 18
+                        response -> response.length() == 18 && response.startsWith(PRODUCT_PREFIX)
                 )
                 .verifyComplete();
     }


### PR DESCRIPTION
depend on https://github.com/pagopa/pagopa-ecommerce-commons/pull/152
depend on https://github.com/pagopa/pagopa-ecommerce-local/pull/106
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
The change was made to ensure the uniqueness of the generation of the orderId to be forwarded to NPG.
In particular, a logic was defined that saves to redis to check that the generated orderId does not collide with other previously received requests.
A prefix was added to the generation of the unique string. **(E)**
The duration of the id in the cache is set to one minute when the collision could occur to the millisecond.
<!--- Describe your changes in detail -->

#### Motivation and Context
The change was made to generate a unique orderId.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.