### PR TITLE
Chk-2126: payment method with clientId

### DIFF
--- a/api-spec/api.yaml
+++ b/api-spec/api.yaml
@@ -58,6 +58,15 @@ paths:
           required: false
           schema:
             type: number
+        - name: x-client-id
+          in: header
+          description: client id related to a given touchpoint
+          required: true
+          schema:
+            type: string
+            enum:
+              - IO
+              - CHECKOUT
       responses:
         '200':
           description: Payment method successfully retrieved
@@ -126,6 +135,15 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-client-id
+          in: header
+          description: client id related to a given touchpoint
+          required: true
+          schema:
+            type: string
+            enum:
+              - IO
+              - CHECKOUT
       responses:
         '200':
           description: New payment method successfully updated
@@ -368,6 +386,12 @@ components:
       type: object
       description: New Payment method Request
       properties:
+        clientId:
+          type: string
+          description: client id related to a given touchpoint
+          enum:
+            - IO
+            - CHECKOUT
         name:
           type: string
           description: Payment method name
@@ -394,6 +418,7 @@ components:
         - status
         - paymentTypeCode
         - ranges
+        - clientId
     Range:
       type: object
       description: Payment amount range in eurocents

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -1,6 +1,5 @@
 package it.pagopa.ecommerce.payment.methods.application;
 
-import io.vavr.Tuple;
 import it.pagopa.ecommerce.commons.client.NpgClient;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.generated.npg.v1.dto.FieldsDto;
@@ -98,7 +97,8 @@ public class PaymentMethodService {
                                                    String paymentMethodDescription,
                                                    List<Pair<Long, Long>> ranges,
                                                    String paymentMethodTypeCode,
-                                                   String paymentMethodAsset
+                                                   String paymentMethodAsset,
+                                                   PaymentMethodRequestDto.ClientIdEnum clientId
     ) {
         log.info("[Payment Method Aggregate] Create new aggregate");
         Mono<PaymentMethod> paymentMethod = paymentMethodFactory.newPaymentMethod(
@@ -109,7 +109,8 @@ public class PaymentMethodService {
                 ranges.stream().map(pair -> new PaymentMethodRange(pair.getFirst(), pair.getSecond())).toList(),
                 new PaymentMethodType(paymentMethodTypeCode),
                 new PaymentMethodAsset(paymentMethodAsset),
-                NpgClient.PaymentMethod.fromServiceName(paymentMethodName)
+                NpgClient.PaymentMethod.fromServiceName(paymentMethodName),
+                clientId
         );
 
         log.info("[Payment Method Aggregate] Store new aggregate");
@@ -124,7 +125,8 @@ public class PaymentMethodService {
                                 p.getPaymentMethodAsset().value(),
                                 p.getPaymentMethodRanges().stream().map(r -> Pair.of(r.min(), r.max()))
                                         .toList(),
-                                p.getPaymentMethodTypeCode().value()
+                                p.getPaymentMethodTypeCode().value(),
+                                p.getClientIdEnum().getValue()
                         )
                 ).map(
                         doc -> new PaymentMethod(
@@ -137,7 +139,8 @@ public class PaymentMethodService {
                                         .map(pair -> new PaymentMethodRange(pair.getFirst(), pair.getSecond()))
                                         .toList(),
                                 new PaymentMethodAsset(doc.getPaymentMethodAsset()),
-                                NpgClient.PaymentMethod.fromServiceName(doc.getPaymentMethodName())
+                                NpgClient.PaymentMethod.fromServiceName(doc.getPaymentMethodName()),
+                                clientId
                         )
                 )
         );
@@ -189,7 +192,8 @@ public class PaymentMethodService {
                                                 p.getPaymentMethodRanges().stream().map(
                                                         r -> Pair.of(r.min(), r.max())
                                                 ).toList(),
-                                                p.getPaymentMethodTypeCode().value()
+                                                p.getPaymentMethodTypeCode().value(),
+                                                p.getClientIdEnum().getValue()
                                         )
                                 )
                 )
@@ -551,7 +555,8 @@ public class PaymentMethodService {
                         .map(pair -> new PaymentMethodRange(pair.getFirst(), pair.getSecond()))
                         .toList(),
                 new PaymentMethodAsset(doc.getPaymentMethodAsset()),
-                NpgClient.PaymentMethod.fromServiceName(doc.getPaymentMethodName())
+                NpgClient.PaymentMethod.fromServiceName(doc.getPaymentMethodName()),
+                PaymentMethodRequestDto.ClientIdEnum.fromValue(doc.getClientId())
         );
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -146,14 +146,17 @@ public class PaymentMethodService {
         );
     }
 
-    public Flux<PaymentMethod> retrievePaymentMethods(Integer amount) {
+    public Flux<PaymentMethod> retrievePaymentMethods(
+                                                      Integer amount,
+                                                      String clientId
+    ) {
         log.info("[Payment Method Aggregate] Retrieve Aggregate");
 
         if (amount == null) {
-            return paymentMethodRepository.findAll().map(this::docToAggregate);
+            return paymentMethodRepository.findByClientId(clientId).map(this::docToAggregate);
         } else {
             return paymentMethodRepository
-                    .findAll()
+                    .findByClientId(clientId)
                     .filter(
                             doc -> doc.getPaymentMethodRanges().stream()
                                     .anyMatch(
@@ -200,11 +203,14 @@ public class PaymentMethodService {
                 .map(this::docToAggregate);
     }
 
-    public Mono<PaymentMethod> retrievePaymentMethodById(String id) {
+    public Mono<PaymentMethod> retrievePaymentMethodById(
+                                                         String id,
+                                                         String clientId
+    ) {
         log.info("[Payment Method Aggregate] Retrieve Aggregate");
 
         return paymentMethodRepository
-                .findById(id)
+                .findByIdAndClientId(id, clientId)
                 .switchIfEmpty(Mono.error(new PaymentMethodNotFoundException(id)))
                 .map(this::docToAggregate);
     }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -210,7 +210,7 @@ public class PaymentMethodService {
         log.info("[Payment Method Aggregate] Retrieve Aggregate");
 
         return paymentMethodRepository
-                .findByIdAndClientId(id, clientId)
+                .findByPaymentMethodIDAndClientId(id, clientId)
                 .switchIfEmpty(Mono.error(new PaymentMethodNotFoundException(id)))
                 .map(this::docToAggregate);
     }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -142,7 +142,8 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                 .map(r -> Pair.of(r.getMin(), r.getMax()))
                                 .toList(),
                         request.getPaymentTypeCode(),
-                        request.getAsset()
+                        request.getAsset(),
+                        request.getClientId()
                 )
                         .map(this::paymentMethodToResponse)
         );

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -108,7 +108,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                                                                 BigDecimal amount,
                                                                                 ServerWebExchange exchange
     ) {
-        return paymentMethodService.retrievePaymentMethods(amount != null ? amount.intValue() : null)
+        return paymentMethodService.retrievePaymentMethods(amount != null ? amount.intValue() : null, xClientId)
                 .map(PaymentMethodsController::paymentMethodToDto)
                 .collectList()
                 .map(
@@ -125,7 +125,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                                                            String xClientId,
                                                                            ServerWebExchange exchange
     ) {
-        return paymentMethodService.retrievePaymentMethodById(id)
+        return paymentMethodService.retrievePaymentMethodById(id, xClientId)
                 .map(this::paymentMethodToResponse);
     }
 

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -104,6 +104,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
 
     @Override
     public Mono<ResponseEntity<PaymentMethodsResponseDto>> getAllPaymentMethods(
+                                                                                String xClientId,
                                                                                 BigDecimal amount,
                                                                                 ServerWebExchange exchange
     ) {
@@ -121,6 +122,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
     @Override
     public Mono<ResponseEntity<PaymentMethodResponseDto>> getPaymentMethod(
                                                                            String id,
+                                                                           String xClientId,
                                                                            ServerWebExchange exchange
     ) {
         return paymentMethodService.retrievePaymentMethodById(id)

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethod.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethod.java
@@ -8,6 +8,7 @@ import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodName
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodRange;
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodStatus;
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodType;
+import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodRequestDto;
 import it.pagopa.ecommerce.payment.methods.utils.PaymentMethodStatusEnum;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,8 +26,9 @@ public class PaymentMethod {
     private final List<PaymentMethodRange> paymentMethodRanges;
     private final PaymentMethodType paymentMethodTypeCode;
     private final PaymentMethodAsset paymentMethodAsset;
-
     private final NpgClient.PaymentMethod npgPaymentMethod;
+    private final PaymentMethodRequestDto.ClientIdEnum clientIdEnum;
+
     private PaymentMethodStatus paymentMethodStatus;
 
     /*
@@ -46,7 +48,8 @@ public class PaymentMethod {
             PaymentMethodType paymentMethodTypeCode,
             List<PaymentMethodRange> paymentMethodRanges,
             PaymentMethodAsset paymentMethodAsset,
-            NpgClient.PaymentMethod npgPaymentMethod
+            NpgClient.PaymentMethod npgPaymentMethod,
+            PaymentMethodRequestDto.ClientIdEnum clientIdEnum
     ) {
         this.paymentMethodID = paymentMethodID;
         this.paymentMethodName = paymentMethodName;
@@ -56,6 +59,7 @@ public class PaymentMethod {
         this.paymentMethodRanges = paymentMethodRanges;
         this.paymentMethodAsset = paymentMethodAsset;
         this.npgPaymentMethod = npgPaymentMethod;
+        this.clientIdEnum = clientIdEnum;
     }
 
     @AggregateID

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactory.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactory.java
@@ -9,6 +9,7 @@ import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodRang
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodStatus;
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodType;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepository;
+import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodRequestDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -41,7 +42,8 @@ public class PaymentMethodFactory {
                                                 List<PaymentMethodRange> paymentMethodRanges,
                                                 PaymentMethodType paymentMethodTypeCode,
                                                 PaymentMethodAsset paymentMethodAsset,
-                                                NpgClient.PaymentMethod npgPaymentMethod
+                                                NpgClient.PaymentMethod npgPaymentMethod,
+                                                PaymentMethodRequestDto.ClientIdEnum clientId
     ) {
 
         return paymentMethodRepository.findByPaymentMethodNameOrPaymentMethodTypeCode(
@@ -60,7 +62,8 @@ public class PaymentMethodFactory {
                             paymentMethodTypeCode,
                             paymentMethodRanges,
                             paymentMethodAsset,
-                            npgPaymentMethod
+                            npgPaymentMethod,
+                            clientId
                     );
                 }
                 );

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactory.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactory.java
@@ -46,9 +46,10 @@ public class PaymentMethodFactory {
                                                 PaymentMethodRequestDto.ClientIdEnum clientId
     ) {
 
-        return paymentMethodRepository.findByPaymentMethodNameOrPaymentMethodTypeCode(
+        return paymentMethodRepository.findByPaymentMethodNameAndPaymentMethodTypeCodeAndClientId(
                 paymentMethodName.value(),
-                paymentMethodTypeCode.value()
+                paymentMethodTypeCode.value(),
+                clientId.getValue()
         ).hasElement()
                 .map(hasPaymentMethod -> {
                     if (Boolean.TRUE.equals(hasPaymentMethod)) {

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
@@ -3,9 +3,6 @@ package it.pagopa.ecommerce.payment.methods.infrastructure;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.util.Pair;
 

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
@@ -24,4 +24,5 @@ public class PaymentMethodDocument {
     private List<Pair<Long, Long>> paymentMethodRanges;
     @Indexed(unique = true)
     private String paymentMethodTypeCode;
+    private String clientId;
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
@@ -13,11 +13,6 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-@CompoundIndexes(
-    {
-            @CompoundIndex(name = "paymentMethodName_paymentMethodTypeCode_clientId", unique = true)
-    }
-)
 @Document(collection = "payment-methods")
 public class PaymentMethodDocument {
 

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
@@ -3,6 +3,8 @@ package it.pagopa.ecommerce.payment.methods.infrastructure;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.util.Pair;
@@ -11,18 +13,21 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
+@CompoundIndexes(
+    {
+            @CompoundIndex(name = "paymentMethodName_paymentMethodTypeCode_clientId", unique = true)
+    }
+)
 @Document(collection = "payment-methods")
 public class PaymentMethodDocument {
 
     @Id
     private String paymentMethodID;
-    @Indexed(unique = true)
     private String paymentMethodName;
     private String paymentMethodDescription;
     private String paymentMethodStatus;
     private String paymentMethodAsset;
     private List<Pair<Long, Long>> paymentMethodRanges;
-    @Indexed(unique = true)
     private String paymentMethodTypeCode;
     private String clientId;
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
@@ -20,4 +20,11 @@ public interface PaymentMethodRepository extends ReactiveCrudRepository<PaymentM
                                                                  String paymentMethodID,
                                                                  String clientId
     );
+
+    Mono<PaymentMethodDocument> findByPaymentMethodNameAndPaymentMethodTypeCodeAndClientId(
+                                                                                           String paymentMethodName,
+                                                                                           String paymentMethodTypeCode,
+                                                                                           String clientId
+    );
+
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
@@ -16,8 +16,8 @@ public interface PaymentMethodRepository extends ReactiveCrudRepository<PaymentM
 
     Flux<PaymentMethodDocument> findByClientId(String clientId);
 
-    Mono<PaymentMethodDocument> findByIdAndClientId(
-                                                    String paymentMethodID,
-                                                    String clientId
+    Mono<PaymentMethodDocument> findByPaymentMethodIDAndClientId(
+                                                                 String paymentMethodID,
+                                                                 String clientId
     );
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
@@ -16,7 +16,7 @@ public interface PaymentMethodRepository extends ReactiveCrudRepository<PaymentM
 
     Flux<PaymentMethodDocument> findByClientId(String clientId);
 
-    Mono<PaymentMethodDocument> findByPaymentMethodIdAndClientId(
+    Mono<PaymentMethodDocument> findByPaymentMethodIDAndClientId(
                                                                  String paymentMethodID,
                                                                  String clientId
     );

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
@@ -14,4 +14,10 @@ public interface PaymentMethodRepository extends ReactiveCrudRepository<PaymentM
 
     Flux<PaymentMethodDocument> findByPaymentMethodStatus(String paymentMethodStatus);
 
+    Flux<PaymentMethodDocument> findByClientId(String clientId);
+
+    Mono<PaymentMethodDocument> findByIdAndClientId(
+                                                    String id,
+                                                    String clientId
+    );
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
@@ -17,7 +17,7 @@ public interface PaymentMethodRepository extends ReactiveCrudRepository<PaymentM
     Flux<PaymentMethodDocument> findByClientId(String clientId);
 
     Mono<PaymentMethodDocument> findByIdAndClientId(
-                                                    String _id,
+                                                    String paymentMethodID,
                                                     String clientId
     );
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
@@ -16,7 +16,7 @@ public interface PaymentMethodRepository extends ReactiveCrudRepository<PaymentM
 
     Flux<PaymentMethodDocument> findByClientId(String clientId);
 
-    Mono<PaymentMethodDocument> findByPaymentMethodIDAndClientId(
+    Mono<PaymentMethodDocument> findByPaymentMethodIdAndClientId(
                                                                  String paymentMethodID,
                                                                  String clientId
     );

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodRepository.java
@@ -17,7 +17,7 @@ public interface PaymentMethodRepository extends ReactiveCrudRepository<PaymentM
     Flux<PaymentMethodDocument> findByClientId(String clientId);
 
     Mono<PaymentMethodDocument> findByIdAndClientId(
-                                                    String id,
+                                                    String _id,
                                                     String clientId
     );
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -78,7 +78,7 @@ class PaymentMethodsControllerTests {
 
         PaymentMethodResponseDto methodResponse = TestUtil.getPaymentMethodResponse(paymentMethod);
 
-        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), any()))
+        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), eq(ClientID.IO)))
                 .thenReturn(Mono.just(paymentMethod));
 
         webClient

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -56,7 +56,7 @@ class PaymentMethodsControllerTests {
 
         PaymentMethodResponseDto methodResponse = TestUtil.getPaymentMethodResponse(paymentMethod);
 
-        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), any()))
+        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), eq(CLientID.CHECKOUT)))
                 .thenReturn(Mono.just(paymentMethod));
 
         webClient

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -96,8 +96,11 @@ class PaymentMethodsControllerTests {
     void shouldGetAllMethodsForCheckout() {
 
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdCheckout = TestUtil.getClientIdCheckout();
 
-        Mockito.when(paymentMethodService.retrievePaymentMethods((int) TestUtil.getTestAmount())).thenReturn(
+        Mockito.when(
+                paymentMethodService.retrievePaymentMethods((int) TestUtil.getTestAmount(), clientIdCheckout.getValue())
+        ).thenReturn(
                 Flux.just(paymentMethod)
         );
 
@@ -124,10 +127,12 @@ class PaymentMethodsControllerTests {
     void shouldGetAllMethodsForIo() {
 
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
 
-        Mockito.when(paymentMethodService.retrievePaymentMethods((int) TestUtil.getTestAmount())).thenReturn(
-                Flux.just(paymentMethod)
-        );
+        Mockito.when(paymentMethodService.retrievePaymentMethods((int) TestUtil.getTestAmount(), clientIdIO.getValue()))
+                .thenReturn(
+                        Flux.just(paymentMethod)
+                );
 
         PaymentMethodsResponseDto expectedResult = TestUtil.getPaymentMethodsResponse(paymentMethod);
 
@@ -180,10 +185,12 @@ class PaymentMethodsControllerTests {
     @Test
     void shouldGetAMethodForCheckout() {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdCheckout = TestUtil.getClientIdCheckout();
 
         Mockito.when(
                 paymentMethodService.retrievePaymentMethodById(
-                        paymentMethod.getPaymentMethodID().value().toString()
+                        paymentMethod.getPaymentMethodID().value().toString(),
+                        clientIdCheckout.getValue()
                 )
         ).thenReturn(Mono.just(paymentMethod));
 
@@ -204,10 +211,12 @@ class PaymentMethodsControllerTests {
     @Test
     void shouldGetAMethodForIo() {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
 
         Mockito.when(
                 paymentMethodService.retrievePaymentMethodById(
-                        paymentMethod.getPaymentMethodID().value().toString()
+                        paymentMethod.getPaymentMethodID().value().toString(),
+                        clientIdIO.getValue()
                 )
         ).thenReturn(Mono.just(paymentMethod));
 

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -56,7 +56,7 @@ class PaymentMethodsControllerTests {
 
         PaymentMethodResponseDto methodResponse = TestUtil.getPaymentMethodResponse(paymentMethod);
 
-        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any()))
+        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Mono.just(paymentMethod));
 
         webClient
@@ -78,7 +78,7 @@ class PaymentMethodsControllerTests {
 
         PaymentMethodResponseDto methodResponse = TestUtil.getPaymentMethodResponse(paymentMethod);
 
-        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any()))
+        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Mono.just(paymentMethod));
 
         webClient

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -53,10 +53,11 @@ class PaymentMethodsControllerTests {
         PaymentMethodRequestDto paymentMethodRequestDto = TestUtil.getPaymentMethodRequestForCheckout();
 
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdCheckout = TestUtil.getClientIdCheckout();
 
         PaymentMethodResponseDto methodResponse = TestUtil.getPaymentMethodResponse(paymentMethod);
 
-        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), eq(CLientID.CHECKOUT)))
+        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), eq(clientIdCheckout)))
                 .thenReturn(Mono.just(paymentMethod));
 
         webClient
@@ -75,10 +76,11 @@ class PaymentMethodsControllerTests {
         PaymentMethodRequestDto paymentMethodRequestDto = TestUtil.getPaymentMethodRequestForIO();
 
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
 
         PaymentMethodResponseDto methodResponse = TestUtil.getPaymentMethodResponse(paymentMethod);
 
-        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), eq(ClientID.IO)))
+        Mockito.when(paymentMethodService.createPaymentMethod(any(), any(), any(), any(), any(), eq(clientIdIO)))
                 .thenReturn(Mono.just(paymentMethod));
 
         webClient

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
@@ -50,7 +50,8 @@ class PaymentMethodFactoryTests {
                 paymentMethod.getPaymentMethodRanges(),
                 paymentMethod.getPaymentMethodTypeCode(),
                 paymentMethod.getPaymentMethodAsset(),
-                paymentMethod.getNpgPaymentMethod()
+                paymentMethod.getNpgPaymentMethod(),
+                paymentMethod.getClientIdEnum()
         ).block();
 
         assertNotNull(paymentMethodProduct);
@@ -76,7 +77,8 @@ class PaymentMethodFactoryTests {
                                 paymentMethod.getPaymentMethodRanges().stream()
                                         .map(r -> Pair.of(r.min(), r.max()))
                                         .collect(Collectors.toList()),
-                                paymentMethod.getPaymentMethodTypeCode().value()
+                                paymentMethod.getPaymentMethodTypeCode().value(),
+                                paymentMethod.getNpgPaymentMethod().toString()
                         )
                 )
         );
@@ -91,7 +93,8 @@ class PaymentMethodFactoryTests {
                         paymentMethod.getPaymentMethodRanges(),
                         paymentMethod.getPaymentMethodTypeCode(),
                         paymentMethod.getPaymentMethodAsset(),
-                        paymentMethod.getNpgPaymentMethod()
+                        paymentMethod.getNpgPaymentMethod(),
+                        paymentMethod.getClientIdEnum()
                 ).block()
         );
     }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
@@ -3,6 +3,7 @@ package it.pagopa.ecommerce.payment.methods.domain.aggregates;
 import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodAlreadyInUseException;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodDocument;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepository;
+import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodRequestDto;
 import it.pagopa.ecommerce.payment.methods.utils.TestUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,10 +36,13 @@ class PaymentMethodFactoryTests {
     void shouldCreateNewmethod() {
 
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
+
         Mockito.when(
-                paymentMethodRepository.findByPaymentMethodNameOrPaymentMethodTypeCode(
+                paymentMethodRepository.findByPaymentMethodNameAndPaymentMethodTypeCodeAndClientId(
                         paymentMethod.getPaymentMethodName().value(),
-                        paymentMethod.getPaymentMethodTypeCode().value()
+                        paymentMethod.getPaymentMethodTypeCode().value(),
+                        clientIdIO.getValue()
                 )
         ).thenReturn(Mono.empty());
 
@@ -60,11 +64,13 @@ class PaymentMethodFactoryTests {
     @Test
     void shouldThrowDuplicatedMethodException() {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
 
         Mockito.when(
-                paymentMethodRepository.findByPaymentMethodNameOrPaymentMethodTypeCode(
+                paymentMethodRepository.findByPaymentMethodNameAndPaymentMethodTypeCodeAndClientId(
                         paymentMethod.getPaymentMethodName().value(),
-                        paymentMethod.getPaymentMethodTypeCode().value()
+                        paymentMethod.getPaymentMethodTypeCode().value(),
+                        clientIdIO.getValue()
                 )
         ).thenReturn(
                 Mono.just(

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
@@ -36,13 +36,13 @@ class PaymentMethodFactoryTests {
     void shouldCreateNewmethod() {
 
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
-        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
+        PaymentMethodRequestDto.ClientIdEnum clientIdCheckout = TestUtil.getClientIdCheckout();
 
         Mockito.when(
                 paymentMethodRepository.findByPaymentMethodNameAndPaymentMethodTypeCodeAndClientId(
                         paymentMethod.getPaymentMethodName().value(),
                         paymentMethod.getPaymentMethodTypeCode().value(),
-                        clientIdIO.getValue()
+                        clientIdCheckout.getValue()
                 )
         ).thenReturn(Mono.empty());
 
@@ -64,13 +64,13 @@ class PaymentMethodFactoryTests {
     @Test
     void shouldThrowDuplicatedMethodException() {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
-        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
+        PaymentMethodRequestDto.ClientIdEnum clientIdCheckout = TestUtil.getClientIdCheckout();
 
         Mockito.when(
                 paymentMethodRepository.findByPaymentMethodNameAndPaymentMethodTypeCodeAndClientId(
                         paymentMethod.getPaymentMethodName().value(),
                         paymentMethod.getPaymentMethodTypeCode().value(),
-                        clientIdIO.getValue()
+                        clientIdCheckout.getValue()
                 )
         ).thenReturn(
                 Mono.just(
@@ -84,7 +84,7 @@ class PaymentMethodFactoryTests {
                                         .map(r -> Pair.of(r.min(), r.max()))
                                         .collect(Collectors.toList()),
                                 paymentMethod.getPaymentMethodTypeCode().value(),
-                                paymentMethod.getNpgPaymentMethod().toString()
+                                clientIdCheckout.getValue()
                         )
                 )
         );

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
@@ -128,13 +128,15 @@ class PaymentMethodServiceTests {
     @Test
     void shouldRetrievePaymentMethods() {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdEnumCheckout = TestUtil.getClientIdCheckout();
 
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
 
         Mockito.when(paymentMethodRepository.findAll())
                 .thenReturn(Flux.just(paymentMethodDocument));
 
-        PaymentMethod paymentMethodCreated = paymentMethodService.retrievePaymentMethods(null).blockFirst();
+        PaymentMethod paymentMethodCreated = paymentMethodService
+                .retrievePaymentMethods(null, clientIdEnumCheckout.getValue()).blockFirst();
 
         assertEquals(paymentMethodCreated.getPaymentMethodID(), paymentMethod.getPaymentMethodID());
     }
@@ -144,11 +146,13 @@ class PaymentMethodServiceTests {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
 
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
+        PaymentMethodRequestDto.ClientIdEnum clientIdEnumIo = TestUtil.getClientIdIO();
 
         Mockito.when(paymentMethodRepository.findAll())
                 .thenReturn(Flux.just(paymentMethodDocument));
 
-        List<PaymentMethod> paymentMethodCreated = paymentMethodService.retrievePaymentMethods(101)
+        List<PaymentMethod> paymentMethodCreated = paymentMethodService
+                .retrievePaymentMethods(101, clientIdEnumIo.getValue())
                 .collectList().block();
 
         assertEquals(0, paymentMethodCreated.size());
@@ -159,11 +163,13 @@ class PaymentMethodServiceTests {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
 
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
+        PaymentMethodRequestDto.ClientIdEnum clientIdEnumIo = TestUtil.getClientIdIO();
 
         Mockito.when(paymentMethodRepository.findAll())
                 .thenReturn(Flux.just(paymentMethodDocument));
 
-        List<PaymentMethod> paymentmethodCreated = paymentMethodService.retrievePaymentMethods(50)
+        List<PaymentMethod> paymentmethodCreated = paymentMethodService
+                .retrievePaymentMethods(50, clientIdEnumIo.getValue())
                 .collectList().block();
 
         assertEquals(1, paymentmethodCreated.size());
@@ -206,13 +212,21 @@ class PaymentMethodServiceTests {
     @Test
     void shouldRetrievePaymentMethodById() {
         PaymentMethod paymentMethod = TestUtil.getPaymentMethod();
+        PaymentMethodRequestDto.ClientIdEnum clientIdIO = TestUtil.getClientIdIO();
+
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
 
-        Mockito.when(paymentMethodRepository.findById(paymentMethod.getPaymentMethodID().value().toString()))
+        Mockito.when(
+                paymentMethodRepository.findByIdAndClientId(
+                        paymentMethod.getPaymentMethodID().value().toString(),
+                        clientIdIO.getValue()
+                )
+        )
                 .thenReturn(Mono.just(paymentMethodDocument));
 
         PaymentMethod paymentMethodCreated = paymentMethodService
-                .retrievePaymentMethodById(paymentMethod.getPaymentMethodID().value().toString()).block();
+                .retrievePaymentMethodById(paymentMethod.getPaymentMethodID().value().toString(), clientIdIO.getValue())
+                .block();
 
         assertEquals(paymentMethodCreated.getPaymentMethodID(), paymentMethod.getPaymentMethodID());
     }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
@@ -132,7 +132,7 @@ class PaymentMethodServiceTests {
 
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
 
-        Mockito.when(paymentMethodRepository.findAll())
+        Mockito.when(paymentMethodRepository.findByClientId(clientIdEnumCheckout.getValue()))
                 .thenReturn(Flux.just(paymentMethodDocument));
 
         PaymentMethod paymentMethodCreated = paymentMethodService
@@ -148,7 +148,7 @@ class PaymentMethodServiceTests {
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
         PaymentMethodRequestDto.ClientIdEnum clientIdEnumIo = TestUtil.getClientIdIO();
 
-        Mockito.when(paymentMethodRepository.findAll())
+        Mockito.when(paymentMethodRepository.findByClientId(clientIdEnumIo.getValue()))
                 .thenReturn(Flux.just(paymentMethodDocument));
 
         List<PaymentMethod> paymentMethodCreated = paymentMethodService
@@ -165,7 +165,7 @@ class PaymentMethodServiceTests {
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
         PaymentMethodRequestDto.ClientIdEnum clientIdEnumIo = TestUtil.getClientIdIO();
 
-        Mockito.when(paymentMethodRepository.findAll())
+        Mockito.when(paymentMethodRepository.findByClientId(clientIdEnumIo.getValue()))
                 .thenReturn(Flux.just(paymentMethodDocument));
 
         List<PaymentMethod> paymentmethodCreated = paymentMethodService
@@ -217,7 +217,7 @@ class PaymentMethodServiceTests {
         PaymentMethodDocument paymentMethodDocument = TestUtil.getTestPaymentDoc(paymentMethod);
 
         Mockito.when(
-                paymentMethodRepository.findByIdAndClientId(
+                paymentMethodRepository.findByPaymentMethodIDAndClientId(
                         paymentMethod.getPaymentMethodID().value().toString(),
                         clientIdIO.getValue()
                 )

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
@@ -99,6 +99,7 @@ class PaymentMethodServiceTests {
                         any(),
                         any(),
                         any(),
+                        any(),
                         any()
                 )
         )
@@ -117,7 +118,8 @@ class PaymentMethodServiceTests {
                 paymentMethod.getPaymentMethodRanges().stream().map(r -> Pair.of(r.min(), r.max()))
                         .collect(Collectors.toList()),
                 paymentMethod.getPaymentMethodTypeCode().value(),
-                paymentMethod.getPaymentMethodAsset().value()
+                paymentMethod.getPaymentMethodAsset().value(),
+                paymentMethod.getClientIdEnum()
         ).block();
 
         assertEquals(paymentMethodResponse.getPaymentMethodID(), paymentMethod.paymentMethodID());
@@ -227,7 +229,8 @@ class PaymentMethodServiceTests {
                 PaymentMethodStatusEnum.ENABLED.getCode(),
                 "asset",
                 List.of(Pair.of(0L, 100L)),
-                "CP"
+                "CP",
+                PaymentMethodRequestDto.ClientIdEnum.CHECKOUT.getValue()
         );
         Mockito.when(paymentMethodRepository.findById(paymentMethodId))
                 .thenReturn(
@@ -265,7 +268,8 @@ class PaymentMethodServiceTests {
                                         PaymentMethodStatusEnum.ENABLED.getCode(),
                                         "asset",
                                         List.of(Pair.of(0L, 100L)),
-                                        "CP"
+                                        "CP",
+                                        PaymentMethodRequestDto.ClientIdEnum.IO.getValue()
                                 )
                         )
                 );
@@ -296,7 +300,8 @@ class PaymentMethodServiceTests {
                                         PaymentMethodStatusEnum.ENABLED.getCode(),
                                         "asset",
                                         List.of(Pair.of(0L, 100L)),
-                                        paymentTypeCode
+                                        paymentTypeCode,
+                                        PaymentMethodRequestDto.ClientIdEnum.CHECKOUT.getValue()
                                 )
                         )
                 );

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -57,7 +57,8 @@ public class TestUtil {
                 new PaymentMethodType(TEST_TYPE_CODE),
                 List.of(new PaymentMethodRange(0L, 100L)),
                 new PaymentMethodAsset(TEST_ASSET),
-                TEST_NPG_PAYMENT_METHOD
+                TEST_NPG_PAYMENT_METHOD,
+                getClientIdCheckout()
         );
     }
 
@@ -138,7 +139,8 @@ public class TestUtil {
                 paymentMethod.getPaymentMethodAsset().value(),
                 paymentMethod.getPaymentMethodRanges().stream().map(r -> Pair.of(r.min(), r.max()))
                         .collect(Collectors.toList()),
-                paymentMethod.getPaymentMethodTypeCode().value()
+                paymentMethod.getPaymentMethodTypeCode().value(),
+                paymentMethod.getClientIdEnum().getValue()
         );
     }
 

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -61,8 +61,20 @@ public class TestUtil {
         );
     }
 
-    public static PaymentMethodRequestDto getPaymentMethodRequest() {
+    public static PaymentMethodRequestDto getPaymentMethodRequestForCheckout() {
         return new PaymentMethodRequestDto()
+                .clientId(getClientIdCheckout())
+                .name(TEST_NAME)
+                .description(TEST_DESC)
+                .status(TEST_STATUS)
+                .paymentTypeCode(TEST_TYPE_CODE)
+                .ranges(List.of(new RangeDto().max(100L).min(0L)))
+                .asset(TEST_ASSET);
+    }
+
+    public static PaymentMethodRequestDto getPaymentMethodRequestForIO() {
+        return new PaymentMethodRequestDto()
+                .clientId(getClientIdIO())
                 .name(TEST_NAME)
                 .description(TEST_DESC)
                 .status(TEST_STATUS)
@@ -323,5 +335,13 @@ public class TestUtil {
                         )
                 );
 
+    }
+
+    public static PaymentMethodRequestDto.ClientIdEnum getClientIdCheckout() {
+        return PaymentMethodRequestDto.ClientIdEnum.CHECKOUT;
+    }
+
+    public static PaymentMethodRequestDto.ClientIdEnum getClientIdIO() {
+        return PaymentMethodRequestDto.ClientIdEnum.IO;
     }
 }


### PR DESCRIPTION
depends on https://github.com/pagopa/pagopa-ecommerce-local/pull/108
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- add `x-client-id` header param for:
  - `GET payment-methods`
  - `GET payment-methods/:id`
- add `clientId` as body param in new payment methods
- filter all get methods with clientId
- updata mongo document with clientId
- new compound unique index for payment method, in only to have unique payment method given clientID, name and type code
#### Motivation and Context

The goal of this PR is to handle differente payment methods according to client ID, so touchpoint Id related to payment methods.

#### How Has This Been Tested?

- run unit test
- run integration test

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.