### PR TITLE
fix: handle no bundle returned by GEC with 404 error code

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -39,7 +39,8 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                 AfmResponseException.class,
                 InvalidSessionException.class,
                 MismatchedSecurityTokenException.class,
-                SessionAlreadyAssociatedToTransaction.class
+                SessionAlreadyAssociatedToTransaction.class,
+                NoBundleFoundException.class
         }
     )
     public ResponseEntity<ProblemJsonDto> errorHandler(RuntimeException exception) {
@@ -93,6 +94,12 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                     new ProblemJsonDto().status(502).title("Bad Gateway")
                             .detail(exception.getMessage()),
                     HttpStatus.BAD_GATEWAY
+            );
+        } else if (exception instanceof NoBundleFoundException ex) {
+            return new ResponseEntity<>(
+                    new ProblemJsonDto().status(404).title(notFoundTitle).detail(ex.getMessage())
+                            .detail(exception.getMessage()),
+                    HttpStatus.NOT_FOUND
             );
         } else {
             return new ResponseEntity<>(

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/exception/NoBundleFoundException.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/exception/NoBundleFoundException.java
@@ -1,0 +1,33 @@
+package it.pagopa.ecommerce.payment.methods.exception;
+
+/**
+ * Exception raised when no bundle is found for searched payment method
+ */
+public class NoBundleFoundException extends RuntimeException {
+
+    private final String paymentMethodId;
+    private final long amount;
+
+    private final String touchPoint;
+
+    /**
+     * Constructor
+     *
+     * @param paymentMethodId searched payment method id
+     * @param amount          amount for which calculate fees
+     * @param touchPoint      touchPoint used to filter payment methods
+     */
+    public NoBundleFoundException(
+            String paymentMethodId,
+            long amount,
+            String touchPoint
+    ) {
+        super(
+                "No bundle found for payment method with id: [%s] and transaction amount: [%s] for touch point: [%s]"
+                        .formatted(paymentMethodId, amount, touchPoint)
+        );
+        this.paymentMethodId = paymentMethodId;
+        this.amount = amount;
+        this.touchPoint = touchPoint;
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -502,4 +502,26 @@ class PaymentMethodsControllerTests {
                 .expectBody(ProblemJsonDto.class)
                 .isEqualTo(expected);
     }
+
+    @Test
+    void shouldReturn404ForNoBundleReturned() {
+        String paymentMethodId = UUID.randomUUID().toString();
+        CalculateFeeRequestDto requestBody = TestUtil.getCalculateFeeRequest();
+        Mockito.when(paymentMethodService.computeFee(any(), any(), any()))
+                .thenReturn(Mono.error(new NoBundleFoundException("paymentMethodId", 100, "CHECKOUT")));
+        ProblemJsonDto expected = new ProblemJsonDto().status(404).title("Not found").detail(
+                "No bundle found for payment method with id: [paymentMethodId] and transaction amount: [100] for touch point: [CHECKOUT]"
+        );
+        webClient
+                .post()
+                .uri("/payment-methods/" + paymentMethodId + "/fees")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus()
+                .isNotFound()
+                .expectBody(ProblemJsonDto.class)
+                .isEqualTo(expected);
+    }
+
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Handle GEC `calculateFees` responses without bundles (empty or null list) returning 404 error code for those cases
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to properly handle cases for which GEC does not return any bundle for input search criteria
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.