### PR TITLE
[CHK 2440] management correlationId into NPG create session response 

### DIFF
--- a/api-spec/api.yaml
+++ b/api-spec/api.yaml
@@ -650,11 +650,16 @@ components:
         orderId:
           type: string
           description: Identifier of the payment gateway session associated to the form
+        correlationId:
+          type: string
+          format: uuid
+          description: Identifier of the payment gateway session associated to the transaction flow
         paymentMethodData:
           $ref: "#/components/schemas/CardFormFields"
       required:
         - paymentMethodData
         - orderId
+        - correlationId
     CardFormFields:
       type: object
       description: Form fields for credit cards

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -304,6 +304,10 @@ public class PaymentMethodService {
     public Mono<CreateSessionResponseDto> createSessionForPaymentMethod(
                                                                         String id
     ) {
+        log.info(
+                "[Payment Method service] create new NPG sessions using paymentMethodId: {}",
+                id
+        );
         return paymentMethodRepository.findById(id)
                 .map(PaymentMethodDocument::getPaymentMethodName)
                 .map(NpgClient.PaymentMethod::fromServiceName)
@@ -329,6 +333,7 @@ public class PaymentMethodService {
                 )
                 .flatMap(data -> {
                     UUID correlationId = UUID.randomUUID();
+                    log.info("Generated correlationId for execute NPG build session: {}", correlationId);
                     NpgClient.PaymentMethod paymentMethod = data.getT2();
                     String orderId = data.getT1();
                     String notificationSessionToken = data.getT3();
@@ -359,6 +364,7 @@ public class PaymentMethodService {
                             null, // customerId
                             paymentMethod, // paymentMethod
                             npgDefaultApiKey // defaultApiKey
+
                     ).map(form -> Tuples.of(form, sessionPaymentMethod, orderId, correlationId));
                 }).map(data -> {
                     FieldsDto fields = data.getT1();

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -328,13 +328,13 @@ public class PaymentMethodService {
                         )
                 )
                 .flatMap(data -> {
+                    UUID correlationId = UUID.randomUUID();
                     NpgClient.PaymentMethod paymentMethod = data.getT2();
                     String orderId = data.getT1();
                     String notificationSessionToken = data.getT3();
                     SessionPaymentMethod sessionPaymentMethod = SessionPaymentMethod
                             .fromValue(paymentMethod.serviceName);
                     URI returnUrlBasePath = sessionUrlConfig.basePath();
-                    UUID correlationId = UUID.randomUUID();
                     URI resultUrl = returnUrlBasePath.resolve(sessionUrlConfig.outcomeSuffix());
                     URI merchantUrl = returnUrlBasePath;
                     URI cancelUrl = returnUrlBasePath.resolve(sessionUrlConfig.cancelSuffix());
@@ -359,14 +359,16 @@ public class PaymentMethodService {
                             null, // customerId
                             paymentMethod, // paymentMethod
                             npgDefaultApiKey // defaultApiKey
-                    ).map(form -> Tuples.of(form, sessionPaymentMethod, orderId));
+                    ).map(form -> Tuples.of(form, sessionPaymentMethod, orderId, correlationId));
                 }).map(data -> {
                     FieldsDto fields = data.getT1();
                     String orderId = data.getT3();
+                    UUID correlationId = data.getT4();
                     npgSessionsTemplateWrapper
                             .save(
                                     new NpgSessionDocument(
                                             orderId,
+                                            correlationId.toString(),
                                             fields.getSessionId(),
                                             fields.getSecurityToken(),
                                             null,
@@ -378,8 +380,10 @@ public class PaymentMethodService {
                     FieldsDto fields = data.getT1();
                     SessionPaymentMethod paymentMethod = data.getT2();
                     String orderId = data.getT3();
+                    UUID correlationId = data.getT4();
                     return new CreateSessionResponseDto()
                             .orderId(orderId)
+                            .correlationId(correlationId)
                             .paymentMethodData(
                                     new CardFormFieldsDto()
                                             .paymentMethod(paymentMethod.value)
@@ -439,6 +443,7 @@ public class PaymentMethodService {
                                                         el -> npgSessionsTemplateWrapper.save(
                                                                 new NpgSessionDocument(
                                                                         sx.orderId(),
+                                                                        sx.correlationId(),
                                                                         sx.sessionId(),
                                                                         sx.securityToken(),
                                                                         new CardDataDocument(
@@ -529,6 +534,7 @@ public class PaymentMethodService {
                 .map(d -> {
                     NpgSessionDocument updatedDocument = new NpgSessionDocument(
                             d.orderId(),
+                            d.correlationId(),
                             d.sessionId(),
                             d.securityToken(),
                             d.cardData(),

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/NpgSessionDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/NpgSessionDocument.java
@@ -9,6 +9,7 @@ import org.springframework.lang.Nullable;
 @RedisHash(value = "keys", timeToLive = 10 * 60)
 public record NpgSessionDocument(
         @NonNull @Id String orderId,
+        @NonNull String correlationId,
         @NonNull String sessionId,
         @NonNull String securityToken,
         @Nullable CardDataDocument cardData,

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -269,8 +269,9 @@ class PaymentMethodsControllerTests {
         String paymentMethodId = UUID.randomUUID().toString();
         PatchSessionRequestDto requestBody = TestUtil.patchSessionRequest();
         String newTransactionId = requestBody.getTransactionId();
-
-        NpgSessionDocument originalSession = TestUtil.npgSessionDocument("orderId", "sessionId", false, null);
+        String correlationId = UUID.randomUUID().toString();
+        NpgSessionDocument originalSession = TestUtil
+                .npgSessionDocument("orderId", correlationId, "sessionId", false, null);
         NpgSessionDocument updatedDocument = TestUtil.patchSessionResponse(originalSession, newTransactionId);
 
         Mockito.when(paymentMethodService.updateSession(paymentMethodId, originalSession.orderId(), requestBody))

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -298,6 +298,7 @@ public class TestUtil {
 
     public static NpgSessionDocument npgSessionDocument(
                                                         String orderId,
+                                                        String correlationId,
                                                         String sessionId,
                                                         boolean hasCardDataInformation,
                                                         String transactionId
@@ -306,13 +307,14 @@ public class TestUtil {
         if (hasCardDataInformation) {
             document = new NpgSessionDocument(
                     orderId,
+                    correlationId,
                     sessionId,
                     "securityToken",
                     new CardDataDocument("12345678", "1234", "0424", "VISA"),
                     transactionId
             );
         } else {
-            document = new NpgSessionDocument(orderId, sessionId, "securityToken", null, transactionId);
+            document = new NpgSessionDocument(orderId, correlationId, sessionId, "securityToken", null, transactionId);
         }
         return document;
     }
@@ -327,6 +329,7 @@ public class TestUtil {
     ) {
         return new NpgSessionDocument(
                 document.orderId(),
+                document.correlationId(),
                 document.sessionId(),
                 document.securityToken(),
                 document.cardData(),


### PR DESCRIPTION
depend on https://github.com/pagopa/pagopa-infra/pull/1722
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added saving to redis of the correlationId. 
Also added in the api response json to create the session on NPG. 
This field will be useful for the FE to proceed with the flow using the same correlationId
<!--- Describe your changes in detail -->

#### Motivation and Context
The change was made to handle with a single correlationId the whole checkout transaction with NPG.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.