### PR TITLE
feat: add brandAssets map to payment method

### DIFF
--- a/api-spec/api.yaml
+++ b/api-spec/api.yaml
@@ -414,6 +414,12 @@ components:
             $ref: "#/components/schemas/Range"
         methodManagement:
           $ref: "#/components/schemas/PaymentMethodManagementType"
+        brandAssets:
+          description: Brand assets map associated to the method
+          type: object
+          additionalProperties:
+            type: string
+
       required:
         - name
         - description
@@ -545,11 +551,20 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Bundle"
+        asset:
+          description: Payment method asset
+          type: string
+        brandAssets:
+          description: Brand assets map associated to the selected payment method
+          type: object
+          additionalProperties:
+            type: string
       required:
         - bundles
         - paymentMethodName
         - paymentMethodStatus
         - paymentMethodDescription
+        - asset
     Bundle:
       description: Bundle object
       type: object

--- a/api-spec/api.yaml
+++ b/api-spec/api.yaml
@@ -479,6 +479,11 @@ components:
           minItems: 1
           items:
             $ref: "#/components/schemas/Range"
+        brandAssets:
+          description: Brand assets map associated to the selected payment method
+          type: object
+          additionalProperties:
+            type: string
       required:
         - id
         - name

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-afm-calculator/main/openapi/openapi-node.json</inputSpec>
+							<inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-afm-calculator/main/openapi/openapi-node-v1.json</inputSpec>
 							<generatorName>java</generatorName>
 							<library>webclient</library>
 							<generateApiDocumentation>false</generateApiDocumentation>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-afm-calculator/b7086dddcf633f30283fe567c51fa739a685fe37/openapi/openapi-node-v1.json</inputSpec>
+							<inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-afm-calculator/b7086dddcf633f30283fe567c51fa739a685fe37/openapi/openapi-v1.json</inputSpec>
 							<generatorName>java</generatorName>
 							<library>webclient</library>
 							<generateApiDocumentation>false</generateApiDocumentation>

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodService.java
@@ -169,7 +169,7 @@ public class PaymentMethodService {
                                 new PaymentMethodManagement(
                                         PaymentMethodManagementTypeDto.valueOf(doc.getMethodManagement())
                                 ),
-                                new PaymentMethodBrandAssets(Optional.of(doc.getPaymentMethodsBrandAssets()))
+                                new PaymentMethodBrandAssets(Optional.ofNullable(doc.getPaymentMethodsBrandAssets()))
                         )
                 )
         );
@@ -639,7 +639,7 @@ public class PaymentMethodService {
                 new PaymentMethodManagement(
                         PaymentMethodManagementTypeDto.valueOf(doc.getMethodManagement())
                 ),
-                new PaymentMethodBrandAssets(Optional.of(doc.getPaymentMethodsBrandAssets()))
+                new PaymentMethodBrandAssets(Optional.ofNullable(doc.getPaymentMethodsBrandAssets()))
         );
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -10,7 +10,6 @@ import it.pagopa.ecommerce.payment.methods.server.model.*;
 import it.pagopa.ecommerce.payment.methods.utils.PaymentMethodStatusEnum;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.util.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -156,17 +155,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                                                            ServerWebExchange exchange
     ) {
         return paymentMethodRequestDto.flatMap(
-                request -> paymentMethodService.createPaymentMethod(
-                        request.getName(),
-                        request.getDescription(),
-                        request.getRanges().stream()
-                                .map(r -> Pair.of(r.getMin(), r.getMax()))
-                                .toList(),
-                        request.getPaymentTypeCode(),
-                        request.getAsset(),
-                        request.getClientId(),
-                        request.getMethodManagement()
-                )
+                request -> paymentMethodService.createPaymentMethod(request)
                         .map(this::paymentMethodToResponse)
         );
     }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsController.java
@@ -207,6 +207,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
         response.setMethodManagement(
                 paymentMethod.getPaymentMethodManagement().value()
         );
+        response.setBrandAssets(paymentMethod.getPaymentMethodBrandAsset().brandAssets().orElse(null));
         return response;
     }
 

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethod.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethod.java
@@ -30,7 +30,9 @@ public class PaymentMethod {
 
     private PaymentMethodStatus paymentMethodStatus;
 
-    private PaymentMethodManagement paymentMethodManagement;
+    private final PaymentMethodManagement paymentMethodManagement;
+
+    private final PaymentMethodBrandAssets paymentMethodBrandAsset;
 
     private static final Set<String> MANAGED_REDIRECT_PAYMENT_METHOD_TYPE_CODES = Arrays
             .stream(RedirectPaymentMethodTypeCode.values())
@@ -55,7 +57,8 @@ public class PaymentMethod {
             List<PaymentMethodRange> paymentMethodRanges,
             PaymentMethodAsset paymentMethodAsset,
             PaymentMethodRequestDto.ClientIdEnum clientIdEnum,
-            PaymentMethodManagement paymentMethodManagement
+            PaymentMethodManagement paymentMethodManagement,
+            PaymentMethodBrandAssets paymentMethodBrandAsset
     ) {
         if (paymentMethodManagement.value().equals(PaymentMethodManagementTypeDto.REDIRECT)
                 && !MANAGED_REDIRECT_PAYMENT_METHOD_TYPE_CODES.contains(paymentMethodTypeCode.value())) {
@@ -75,6 +78,7 @@ public class PaymentMethod {
         this.npgPaymentMethod = npgPaymentMethodFromName(paymentMethodName, paymentMethodManagement);
         this.clientIdEnum = clientIdEnum;
         this.paymentMethodManagement = paymentMethodManagement;
+        this.paymentMethodBrandAsset = paymentMethodBrandAsset;
     }
 
     @AggregateID

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactory.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactory.java
@@ -1,6 +1,5 @@
 package it.pagopa.ecommerce.payment.methods.domain.aggregates;
 
-import it.pagopa.ecommerce.commons.client.NpgClient;
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.*;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepository;
 import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodRequestDto;
@@ -37,7 +36,8 @@ public class PaymentMethodFactory {
                                                 PaymentMethodType paymentMethodTypeCode,
                                                 PaymentMethodAsset paymentMethodAsset,
                                                 PaymentMethodRequestDto.ClientIdEnum clientId,
-                                                PaymentMethodManagement paymentMethodManagement
+                                                PaymentMethodManagement paymentMethodManagement,
+                                                PaymentMethodBrandAssets paymentMethodBrandAsset
     ) {
 
         return paymentMethodRepository.findByPaymentMethodNameAndPaymentMethodTypeCodeAndClientId(
@@ -58,7 +58,8 @@ public class PaymentMethodFactory {
                             paymentMethodRanges,
                             paymentMethodAsset,
                             clientId,
-                            paymentMethodManagement
+                            paymentMethodManagement,
+                            paymentMethodBrandAsset
                     );
                 }
                 );

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/domain/valueobjects/PaymentMethodBrandAssets.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/domain/valueobjects/PaymentMethodBrandAssets.java
@@ -1,0 +1,9 @@
+package it.pagopa.ecommerce.payment.methods.domain.valueobjects;
+
+import java.util.Map;
+import java.util.Optional;
+
+@ValueObjects
+public record PaymentMethodBrandAssets(Optional<Map<String, String>> brandAssets) {
+
+}

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/infrastructure/PaymentMethodDocument.java
@@ -7,6 +7,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.util.Pair;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @AllArgsConstructor
@@ -23,4 +24,5 @@ public class PaymentMethodDocument {
     private String paymentMethodTypeCode;
     private String clientId;
     private String methodManagement;
+    private Map<String, String> paymentMethodsBrandAssets;
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/PaymentMethodsControllerTests.java
@@ -31,7 +31,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(SpringExtension.class)
 @WebFluxTest(PaymentMethodsController.class)
@@ -54,13 +55,12 @@ class PaymentMethodsControllerTests {
         PaymentMethodRequestDto paymentMethodRequestDto = TestUtil.getPaymentMethodRequestForCheckout();
 
         PaymentMethod paymentMethod = TestUtil.getNPGPaymentMethod();
-        PaymentMethodRequestDto.ClientIdEnum clientIdCheckout = TestUtil.getClientIdCheckout();
 
         PaymentMethodResponseDto methodResponse = TestUtil.getPaymentMethodResponse(paymentMethod);
 
         Mockito.when(
                 paymentMethodService
-                        .createPaymentMethod(any(), any(), any(), any(), any(), eq(clientIdCheckout), any())
+                        .createPaymentMethod(any())
         )
                 .thenReturn(Mono.just(paymentMethod));
 
@@ -86,7 +86,7 @@ class PaymentMethodsControllerTests {
 
         Mockito.when(
                 paymentMethodService
-                        .createPaymentMethod(any(), any(), any(), any(), any(), eq(clientIdIO), any())
+                        .createPaymentMethod(any())
         )
                 .thenReturn(Mono.just(paymentMethod));
 

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodFactoryTests.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -59,7 +60,8 @@ class PaymentMethodFactoryTests {
                 paymentMethod.getPaymentMethodTypeCode(),
                 paymentMethod.getPaymentMethodAsset(),
                 paymentMethod.getClientIdEnum(),
-                paymentMethod.getPaymentMethodManagement()
+                paymentMethod.getPaymentMethodManagement(),
+                paymentMethod.getPaymentMethodBrandAsset()
         ).block();
 
         assertNotNull(paymentMethodProduct);
@@ -87,7 +89,8 @@ class PaymentMethodFactoryTests {
                 paymentMethod.getPaymentMethodTypeCode(),
                 paymentMethod.getPaymentMethodAsset(),
                 paymentMethod.getClientIdEnum(),
-                paymentMethod.getPaymentMethodManagement()
+                paymentMethod.getPaymentMethodManagement(),
+                paymentMethod.getPaymentMethodBrandAsset()
         ).block();
 
         assertNotNull(paymentMethodProduct);
@@ -117,7 +120,8 @@ class PaymentMethodFactoryTests {
                                         .collect(Collectors.toList()),
                                 paymentMethod.getPaymentMethodTypeCode().value(),
                                 clientIdCheckout.getValue(),
-                                paymentMethod.getPaymentMethodManagement().value().getValue()
+                                paymentMethod.getPaymentMethodManagement().value().getValue(),
+                                paymentMethod.getPaymentMethodBrandAsset().brandAssets().orElse(null)
                         )
                 )
         );
@@ -133,7 +137,8 @@ class PaymentMethodFactoryTests {
                         paymentMethod.getPaymentMethodTypeCode(),
                         paymentMethod.getPaymentMethodAsset(),
                         paymentMethod.getClientIdEnum(),
-                        paymentMethod.getPaymentMethodManagement()
+                        paymentMethod.getPaymentMethodManagement(),
+                        paymentMethod.getPaymentMethodBrandAsset()
                 ).block()
         );
     }
@@ -152,7 +157,8 @@ class PaymentMethodFactoryTests {
                         List.of(new PaymentMethodRange(0L, 100L)),
                         new PaymentMethodAsset("asset"),
                         PaymentMethodRequestDto.ClientIdEnum.CHECKOUT,
-                        new PaymentMethodManagement(PaymentMethodManagementTypeDto.REDIRECT)
+                        new PaymentMethodManagement(PaymentMethodManagementTypeDto.REDIRECT),
+                        new PaymentMethodBrandAssets(Optional.empty())
                 )
         );
 

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodTest.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/domain/aggregates/PaymentMethodTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -46,7 +47,8 @@ public class PaymentMethodTest {
                     List.of(),
                     new PaymentMethodAsset("ASSET_URL"),
                     PaymentMethodRequestDto.ClientIdEnum.CHECKOUT,
-                    paymentMethodManagement
+                    paymentMethodManagement,
+                    new PaymentMethodBrandAssets(Optional.empty())
             );
         });
     }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/PaymentMethodServiceTests.java
@@ -8,6 +8,7 @@ import it.pagopa.ecommerce.commons.exceptions.JWTTokenGenerationException;
 import it.pagopa.ecommerce.commons.generated.npg.v1.dto.CardDataResponseDto;
 import it.pagopa.ecommerce.commons.generated.npg.v1.dto.FieldsDto;
 import it.pagopa.ecommerce.commons.utils.JwtTokenUtils;
+import it.pagopa.ecommerce.commons.utils.UniqueIdUtils;
 import it.pagopa.ecommerce.payment.methods.application.PaymentMethodService;
 import it.pagopa.ecommerce.payment.methods.client.AfmClient;
 import it.pagopa.ecommerce.payment.methods.config.SecretsConfigurations;
@@ -22,7 +23,6 @@ import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepositor
 import it.pagopa.ecommerce.payment.methods.server.model.*;
 import it.pagopa.ecommerce.payment.methods.utils.PaymentMethodStatusEnum;
 import it.pagopa.ecommerce.payment.methods.utils.TestUtil;
-import it.pagopa.ecommerce.commons.utils.UniqueIdUtils;
 import it.pagopa.generated.ecommerce.gec.v1.dto.BundleOptionDto;
 import it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto;
 import org.junit.jupiter.api.Test;
@@ -115,6 +115,7 @@ class PaymentMethodServiceTests {
                         any(),
                         any(),
                         any(),
+                        any(),
                         any()
                 )
         )
@@ -126,16 +127,20 @@ class PaymentMethodServiceTests {
                 )
         )
                 .thenReturn(Mono.just(paymentMethodDocument));
-
+        PaymentMethodRequestDto paymentMethodRequestDto = new PaymentMethodRequestDto()
+                .name(paymentMethod.getPaymentMethodName().value())
+                .description(paymentMethod.getPaymentMethodName().value())
+                .ranges(
+                        paymentMethod.getPaymentMethodRanges().stream()
+                                .map(p -> new RangeDto().max(p.max()).min(p.min())).toList()
+                )
+                .paymentTypeCode(paymentMethod.getPaymentMethodTypeCode().value())
+                .asset(paymentMethod.getPaymentMethodAsset().value())
+                .clientId(paymentMethod.getClientIdEnum())
+                .methodManagement(paymentMethod.getPaymentMethodManagement().value())
+                .brandAssets(paymentMethod.getPaymentMethodBrandAsset().brandAssets().orElse(null));
         PaymentMethod paymentMethodResponse = paymentMethodService.createPaymentMethod(
-                paymentMethod.getPaymentMethodName().value(),
-                paymentMethod.getPaymentMethodDescription().value(),
-                paymentMethod.getPaymentMethodRanges().stream().map(r -> Pair.of(r.min(), r.max()))
-                        .collect(Collectors.toList()),
-                paymentMethod.getPaymentMethodTypeCode().value(),
-                paymentMethod.getPaymentMethodAsset().value(),
-                paymentMethod.getClientIdEnum(),
-                paymentMethod.getPaymentMethodManagement().value()
+                paymentMethodRequestDto
         ).block();
 
         assertEquals(paymentMethodResponse.getPaymentMethodID(), paymentMethod.paymentMethodID());
@@ -261,7 +266,8 @@ class PaymentMethodServiceTests {
                 List.of(Pair.of(0L, 100L)),
                 "CP",
                 PaymentMethodRequestDto.ClientIdEnum.CHECKOUT.getValue(),
-                PaymentMethodManagementTypeDto.ONBOARDABLE.getValue()
+                PaymentMethodManagementTypeDto.ONBOARDABLE.getValue(),
+                null
         );
         Mockito.when(paymentMethodRepository.findById(paymentMethodId))
                 .thenReturn(
@@ -301,7 +307,8 @@ class PaymentMethodServiceTests {
                                         List.of(Pair.of(0L, 100L)),
                                         "CP",
                                         PaymentMethodRequestDto.ClientIdEnum.IO.getValue(),
-                                        PaymentMethodManagementTypeDto.ONBOARDABLE.getValue()
+                                        PaymentMethodManagementTypeDto.ONBOARDABLE.getValue(),
+                                        null
                                 )
                         )
                 );
@@ -334,7 +341,8 @@ class PaymentMethodServiceTests {
                                         List.of(Pair.of(0L, 100L)),
                                         paymentTypeCode,
                                         PaymentMethodRequestDto.ClientIdEnum.CHECKOUT.getValue(),
-                                        PaymentMethodManagementTypeDto.ONBOARDABLE.getValue()
+                                        PaymentMethodManagementTypeDto.ONBOARDABLE.getValue(),
+                                        null
                                 )
                         )
                 );
@@ -680,7 +688,8 @@ class PaymentMethodServiceTests {
                 List.of(Pair.of(0L, 100L)),
                 "CP",
                 PaymentMethodRequestDto.ClientIdEnum.CHECKOUT.getValue(),
-                PaymentMethodManagementTypeDto.ONBOARDABLE.getValue()
+                PaymentMethodManagementTypeDto.ONBOARDABLE.getValue(),
+                null
         );
         Mockito.when(paymentMethodRepository.findById(paymentMethodId))
                 .thenReturn(

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -16,10 +16,7 @@ import org.springframework.data.util.Pair;
 
 import java.math.BigInteger;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class TestUtil {
@@ -52,7 +49,8 @@ public class TestUtil {
                 List.of(new PaymentMethodRange(0L, 100L)),
                 new PaymentMethodAsset(TEST_ASSET),
                 getClientIdCheckout(),
-                new PaymentMethodManagement(PaymentMethodManagementTypeDto.ONBOARDABLE)
+                new PaymentMethodManagement(PaymentMethodManagementTypeDto.ONBOARDABLE),
+                new PaymentMethodBrandAssets(Optional.of(new HashMap<>()))
         );
     }
 
@@ -66,7 +64,8 @@ public class TestUtil {
                 List.of(new PaymentMethodRange(0L, 100L)),
                 new PaymentMethodAsset(TEST_ASSET),
                 getClientIdCheckout(),
-                new PaymentMethodManagement(PaymentMethodManagementTypeDto.REDIRECT)
+                new PaymentMethodManagement(PaymentMethodManagementTypeDto.REDIRECT),
+                new PaymentMethodBrandAssets(Optional.of(new HashMap<>()))
         );
     }
 
@@ -152,7 +151,8 @@ public class TestUtil {
                         .collect(Collectors.toList()),
                 paymentMethod.getPaymentMethodTypeCode().value(),
                 paymentMethod.getClientIdEnum().getValue(),
-                paymentMethod.getPaymentMethodManagement().value().getValue()
+                paymentMethod.getPaymentMethodManagement().value().getValue(),
+                paymentMethod.getPaymentMethodBrandAsset().brandAssets().orElse(null)
         );
     }
 

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -50,7 +50,7 @@ public class TestUtil {
                 new PaymentMethodAsset(TEST_ASSET),
                 getClientIdCheckout(),
                 new PaymentMethodManagement(PaymentMethodManagementTypeDto.ONBOARDABLE),
-                new PaymentMethodBrandAssets(Optional.of(new HashMap<>()))
+                new PaymentMethodBrandAssets(Optional.empty())
         );
     }
 
@@ -65,7 +65,7 @@ public class TestUtil {
                 new PaymentMethodAsset(TEST_ASSET),
                 getClientIdCheckout(),
                 new PaymentMethodManagement(PaymentMethodManagementTypeDto.REDIRECT),
-                new PaymentMethodBrandAssets(Optional.of(new HashMap<>()))
+                new PaymentMethodBrandAssets(Optional.empty())
         );
     }
 


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-infra/pull/1824
Depends on https://github.com/pagopa/pagopa-checkout-tests/pull/88

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
add field `paymentMethodsBrandAssets` to payment method.
<!--- Describe your changes in detail -->

#### Motivation and Context
This field will be used to map brand asset for each required payment method (cards by the moment) allowing to explicit brand to asset mapping
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + tests with eCommerce local + test in dev environment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.