### PR TITLE
fix: add ndot conf for npg client

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/payment/methods/config/NpgWebClientsConfig.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/config/NpgWebClientsConfig.java
@@ -40,7 +40,8 @@ public class NpgWebClientsConfig implements WebFluxConfigurer {
                                         TimeUnit.MILLISECONDS
                                 )
                         )
-                );
+                )
+                .resolver(nameResolverSpec -> nameResolverSpec.ndots(1));
 
         DefaultUriBuilderFactory defaultUriBuilderFactory = new DefaultUriBuilderFactory();
         defaultUriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

-  ndots to 1 to look only for a single dot for NPG client

#### Motivation and Context

The goal of this PR is to  set `ndots` to 1 to look only for a single dot in order to resolve  useless resolutions on  .local (with an increase in response time), so issue like https://repost.aws/knowledge-center/eks-dns-failure.


Useful discussions:
- https://github.com/netty/netty/issues/8880
- https://repost.aws/knowledge-center/eks-dns-failure
- https://github.com/kubernetes/kubernetes/issues/64924
- https://github.com/dotnet/runtime/issues/57792


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.