### PR TITLE
[CHK-3496] add sorting policy to calculateFees method

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
@@ -154,6 +154,25 @@ public class PaymentMethodService {
                                 .taxPayerFee(t.getTaxPayerFee())
                                 .touchpoint(t.getTouchpoint())
                                 .pspBusinessName(t.getPspBusinessName())
+                ).sorted(
+                        (
+                         bundle1,
+                         bundle2
+                        ) -> {
+                            if (bundle1.getOnUs()) {
+                                if (bundle2.getOnUs()) {
+                                    return Long.valueOf(bundle1.getTaxPayerFee() - bundle2.getTaxPayerFee()).intValue();
+                                } else {
+                                    return -1;
+                                }
+                            } else {
+                                if (!bundle2.getOnUs()) {
+                                    return Long.valueOf(bundle1.getTaxPayerFee() - bundle2.getTaxPayerFee()).intValue();
+                                } else {
+                                    return 1;
+                                }
+                            }
+                        }
                 ).toList();
 
         return new CalculateFeeResponseDto()

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
@@ -159,15 +159,15 @@ public class PaymentMethodService {
                          bundle1,
                          bundle2
                         ) -> {
-                            if (bundle1.getOnUs()) {
-                                if (bundle2.getOnUs()) {
-                                    return Long.valueOf(bundle1.getTaxPayerFee() - bundle2.getTaxPayerFee()).intValue();
+                            if (Boolean.TRUE.equals(bundle1.getOnUs())) {
+                                if (Boolean.TRUE.equals(bundle2.getOnUs())) {
+                                    return (int) (bundle1.getTaxPayerFee() - bundle2.getTaxPayerFee());
                                 } else {
                                     return -1;
                                 }
                             } else {
-                                if (!bundle2.getOnUs()) {
-                                    return Long.valueOf(bundle1.getTaxPayerFee() - bundle2.getTaxPayerFee()).intValue();
+                                if (Boolean.FALSE.equals(bundle2.getOnUs())) {
+                                    return (int) (bundle1.getTaxPayerFee() - bundle2.getTaxPayerFee());
                                 } else {
                                     return 1;
                                 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
@@ -191,41 +191,28 @@ public class PaymentMethodService {
         return orderedBundles.stream().toList();
     }
 
-/*
-    private List<BundleDto> sortAndShuffleBundleListWithMoreThanOneOnUs(List<BundleDto> bundles) {
-        Map<Long, List<BundleDto>> bundleMapOnUs = new TreeMap<>();
-        Map<Long, List<BundleDto>> bundleMapNotOnUs = new TreeMap<>();
-        bundles
-                .stream()
-                .filter(BundleDto::getOnUs)
-                .forEach(bundle -> {
-                    Long fees = bundle.getTaxPayerFee();
-                    List<BundleDto> bundlesPerFee = bundleMapOnUs.getOrDefault(fees, new ArrayList<>());
-                    bundlesPerFee.add(bundle);
-                    bundleMapOnUs.put(fees, bundlesPerFee);
-                });
-        bundles
-                .stream()
-                .filter(Predicate.not(BundleDto::getOnUs))
-                .forEach(bundle -> {
-                    Long fees = bundle.getTaxPayerFee();
-                    List<BundleDto> bundlesPerFee = bundleMapNotOnUs.getOrDefault(fees, new ArrayList<>());
-                    bundlesPerFee.add(bundle);
-                    bundleMapNotOnUs.put(fees, bundlesPerFee);
-                });
-        Deque<BundleDto> orderedBundlesOnUs = new LinkedList<>();
-        bundleMapOnUs.values().forEach(bundlesPerFee -> {
-            Collections.shuffle(bundlesPerFee);
-            orderedBundlesOnUs.addAll(bundlesPerFee);
-        });
-        Deque<BundleDto> orderedBundlesNotOnUs = new LinkedList<>();
-        bundleMapNotOnUs.values().forEach(bundlesPerFee -> {
-            Collections.shuffle(bundlesPerFee);
-            orderedBundlesNotOnUs.addAll(bundlesPerFee);
-        });
-        List<BundleDto> resultList = orderedBundlesOnUs.stream().toList();
-        resultList.addAll(orderedBundlesNotOnUs.stream().toList());
-        return resultList;
-    }
- */
+    /*
+     * private List<BundleDto>
+     * sortAndShuffleBundleListWithMoreThanOneOnUs(List<BundleDto> bundles) {
+     * Map<Long, List<BundleDto>> bundleMapOnUs = new TreeMap<>(); Map<Long,
+     * List<BundleDto>> bundleMapNotOnUs = new TreeMap<>(); bundles .stream()
+     * .filter(BundleDto::getOnUs) .forEach(bundle -> { Long fees =
+     * bundle.getTaxPayerFee(); List<BundleDto> bundlesPerFee =
+     * bundleMapOnUs.getOrDefault(fees, new ArrayList<>());
+     * bundlesPerFee.add(bundle); bundleMapOnUs.put(fees, bundlesPerFee); });
+     * bundles .stream() .filter(Predicate.not(BundleDto::getOnUs)) .forEach(bundle
+     * -> { Long fees = bundle.getTaxPayerFee(); List<BundleDto> bundlesPerFee =
+     * bundleMapNotOnUs.getOrDefault(fees, new ArrayList<>());
+     * bundlesPerFee.add(bundle); bundleMapNotOnUs.put(fees, bundlesPerFee); });
+     * Deque<BundleDto> orderedBundlesOnUs = new LinkedList<>();
+     * bundleMapOnUs.values().forEach(bundlesPerFee -> {
+     * Collections.shuffle(bundlesPerFee); orderedBundlesOnUs.addAll(bundlesPerFee);
+     * }); Deque<BundleDto> orderedBundlesNotOnUs = new LinkedList<>();
+     * bundleMapNotOnUs.values().forEach(bundlesPerFee -> {
+     * Collections.shuffle(bundlesPerFee);
+     * orderedBundlesNotOnUs.addAll(bundlesPerFee); }); List<BundleDto> resultList =
+     * orderedBundlesOnUs.stream().toList();
+     * resultList.addAll(orderedBundlesNotOnUs.stream().toList()); return
+     * resultList; }
+     */
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
@@ -190,29 +190,4 @@ public class PaymentMethodService {
         onUsBundle.ifPresent(orderedBundles::addFirst);
         return orderedBundles.stream().toList();
     }
-
-    /*
-     * private List<BundleDto>
-     * sortAndShuffleBundleListWithMoreThanOneOnUs(List<BundleDto> bundles) {
-     * Map<Long, List<BundleDto>> bundleMapOnUs = new TreeMap<>(); Map<Long,
-     * List<BundleDto>> bundleMapNotOnUs = new TreeMap<>(); bundles .stream()
-     * .filter(BundleDto::getOnUs) .forEach(bundle -> { Long fees =
-     * bundle.getTaxPayerFee(); List<BundleDto> bundlesPerFee =
-     * bundleMapOnUs.getOrDefault(fees, new ArrayList<>());
-     * bundlesPerFee.add(bundle); bundleMapOnUs.put(fees, bundlesPerFee); });
-     * bundles .stream() .filter(Predicate.not(BundleDto::getOnUs)) .forEach(bundle
-     * -> { Long fees = bundle.getTaxPayerFee(); List<BundleDto> bundlesPerFee =
-     * bundleMapNotOnUs.getOrDefault(fees, new ArrayList<>());
-     * bundlesPerFee.add(bundle); bundleMapNotOnUs.put(fees, bundlesPerFee); });
-     * Deque<BundleDto> orderedBundlesOnUs = new LinkedList<>();
-     * bundleMapOnUs.values().forEach(bundlesPerFee -> {
-     * Collections.shuffle(bundlesPerFee); orderedBundlesOnUs.addAll(bundlesPerFee);
-     * }); Deque<BundleDto> orderedBundlesNotOnUs = new LinkedList<>();
-     * bundleMapNotOnUs.values().forEach(bundlesPerFee -> {
-     * Collections.shuffle(bundlesPerFee);
-     * orderedBundlesNotOnUs.addAll(bundlesPerFee); }); List<BundleDto> resultList =
-     * orderedBundlesOnUs.stream().toList();
-     * resultList.addAll(orderedBundlesNotOnUs.stream().toList()); return
-     * resultList; }
-     */
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/v1/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/v1/PaymentMethodServiceTests.java
@@ -817,8 +817,8 @@ class PaymentMethodServiceTests {
         assertTrue(
                 serviceResponse.getBundles().stream().max(
                         (
-                                b1,
-                                b2
+                         b1,
+                         b2
                         ) -> (int) (b1.getTaxPayerFee() - b2.getTaxPayerFee())
                 ).get().getTaxPayerFee().equals(
                         serviceResponse.getBundles().get(gecResponse.getBundleOptions().size() - 1).getTaxPayerFee()
@@ -827,8 +827,8 @@ class PaymentMethodServiceTests {
         assertTrue(
                 serviceResponse.getBundles().stream().min(
                         (
-                                b1,
-                                b2
+                         b1,
+                         b2
                         ) -> (int) (b1.getTaxPayerFee() - b2.getTaxPayerFee())
                 ).get().getTaxPayerFee().equals(serviceResponse.getBundles().get(0).getTaxPayerFee())
         );
@@ -894,14 +894,18 @@ class PaymentMethodServiceTests {
         assertFalse(serviceResponse.getBundles().get(4).getOnUs());
         assertFalse(serviceResponse.getBundles().get(5).getOnUs());
 
-        List<it.pagopa.ecommerce.payment.methods.server.model.BundleDto> serviceIdPspOnUsList = serviceResponse.getBundles().stream().filter(it.pagopa.ecommerce.payment.methods.server.model.BundleDto::getOnUs)
+        List<it.pagopa.ecommerce.payment.methods.server.model.BundleDto> serviceIdPspOnUsList = serviceResponse
+                .getBundles().stream().filter(it.pagopa.ecommerce.payment.methods.server.model.BundleDto::getOnUs)
                 .toList();
-        List<it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto> gecIdPspOnUsList = gecResponse.getBundleOptions().stream().filter(it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto::getOnUs)
+        List<it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto> gecIdPspOnUsList = gecResponse.getBundleOptions()
+                .stream().filter(it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto::getOnUs)
                 .toList();
 
-        List<it.pagopa.ecommerce.payment.methods.server.model.BundleDto> serviceIdPspNotOnUsList = serviceResponse.getBundles().stream()
+        List<it.pagopa.ecommerce.payment.methods.server.model.BundleDto> serviceIdPspNotOnUsList = serviceResponse
+                .getBundles().stream()
                 .filter(bundleDto -> !bundleDto.getOnUs()).toList();
-        List<it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto> gecIdPspNotOnUsList = gecResponse.getBundleOptions().stream()
+        List<it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto> gecIdPspNotOnUsList = gecResponse.getBundleOptions()
+                .stream()
                 .filter(transferDto -> Boolean.FALSE.equals(transferDto.getOnUs())).toList();
 
         for (int i = 0; i < serviceIdPspOnUsList.size(); i++) {
@@ -910,7 +914,8 @@ class PaymentMethodServiceTests {
 
         boolean samePositionForAllelements = true;
         for (int i = 0; i < serviceIdPspNotOnUsList.size(); i++) {
-            samePositionForAllelements &= serviceIdPspNotOnUsList.get(i).getIdPsp().equals(gecIdPspNotOnUsList.get(i).getIdPsp());
+            samePositionForAllelements &= serviceIdPspNotOnUsList.get(i).getIdPsp()
+                    .equals(gecIdPspNotOnUsList.get(i).getIdPsp());
         }
         assertFalse(samePositionForAllelements);
     }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
@@ -1,6 +1,8 @@
 package it.pagopa.ecommerce.payment.methods.service.v2;
 
+import static com.mongodb.assertions.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
@@ -13,6 +15,7 @@ import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepositor
 import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodRequestDto;
 import it.pagopa.ecommerce.payment.methods.utils.PaymentMethodStatusEnum;
 import it.pagopa.ecommerce.payment.methods.utils.TestUtil;
+import it.pagopa.ecommerce.payment.methods.v2.server.model.BundleDto;
 import it.pagopa.ecommerce.payment.methods.v2.server.model.CalculateFeeResponseDto;
 import it.pagopa.ecommerce.payment.methods.v2.server.model.PaymentMethodManagementTypeDto;
 import it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto;
@@ -38,6 +41,207 @@ class PaymentMethodServiceTests {
             paymentMethodRepository,
             afmClient
     );
+
+    @Test
+    void shouldReturnsSortedFeeListWithoutOnUs() {
+        final var paymentMethodId = UUID.randomUUID().toString();
+        final var calculateFeeRequestDto = TestUtil.V2.getMultiNoticeFeesRequest();
+        final var gecResponse = TestUtil.V2.getBundleOptionDtoClientResponseWithUnsortedTransferListAllNotOnUs();
+        Mockito.when(paymentMethodRepository.findById(paymentMethodId))
+                .thenReturn(Mono.just(PAYMENT_METHOD_TEST));
+        Mockito.when(afmClient.getFeesForNotices(any(), any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(gecResponse));
+
+        CalculateFeeResponseDto serviceResponse = paymentMethodService
+                .computeFee(calculateFeeRequestDto, paymentMethodId, null).block();
+        assertEquals(gecResponse.getBundleOptions().size(), serviceResponse.getBundles().size());
+        assertEquals(PAYMENT_METHOD_TEST.getPaymentMethodName(), serviceResponse.getPaymentMethodName());
+        assertEquals(
+                PAYMENT_METHOD_TEST.getPaymentMethodDescription(),
+                serviceResponse.getPaymentMethodDescription()
+        );
+        for (int i = 0; i < gecResponse.getBundleOptions().size() - 2; i++) {
+            assertTrue(
+                    serviceResponse.getBundles().get(i).getTaxPayerFee().intValue() < serviceResponse.getBundles()
+                            .get(i + 1).getTaxPayerFee().intValue()
+            );
+        }
+        assertTrue(
+                serviceResponse.getBundles().stream().max(
+                        (
+                         b1,
+                         b2
+                        ) -> (int) (b1.getTaxPayerFee() - b2.getTaxPayerFee())
+                ).get().getTaxPayerFee().equals(
+                        serviceResponse.getBundles().get(gecResponse.getBundleOptions().size() - 1).getTaxPayerFee()
+                )
+        );
+        assertTrue(
+                serviceResponse.getBundles().stream().min(
+                        (
+                         b1,
+                         b2
+                        ) -> (int) (b1.getTaxPayerFee() - b2.getTaxPayerFee())
+                ).get().getTaxPayerFee().equals(serviceResponse.getBundles().get(0).getTaxPayerFee())
+        );
+    }
+
+    @Test
+    void shouldReturnsSortedFeeListPlacingUniqueOnUsInFirstPosition() {
+        final var paymentMethodId = UUID.randomUUID().toString();
+        final var calculateFeeRequestDto = TestUtil.V2.getMultiNoticeFeesRequest();
+        final var gecResponse = TestUtil.V2.getBundleOptionDtoClientResponseWithUnsortedTransferListOnlyOneOnUs();
+        Mockito.when(paymentMethodRepository.findById(paymentMethodId))
+                .thenReturn(Mono.just(PAYMENT_METHOD_TEST));
+        Mockito.when(afmClient.getFeesForNotices(any(), any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(gecResponse));
+
+        CalculateFeeResponseDto serviceResponse = paymentMethodService
+                .computeFee(calculateFeeRequestDto, paymentMethodId, null).block();
+        assertEquals(gecResponse.getBundleOptions().size(), serviceResponse.getBundles().size());
+        assertEquals(PAYMENT_METHOD_TEST.getPaymentMethodName(), serviceResponse.getPaymentMethodName());
+        assertEquals(
+                PAYMENT_METHOD_TEST.getPaymentMethodDescription(),
+                serviceResponse.getPaymentMethodDescription()
+        );
+        assertTrue(serviceResponse.getBundles().get(0).getOnUs());
+        assertFalse(
+                serviceResponse.getBundles().get(0).getTaxPayerFee().intValue() < serviceResponse.getBundles().get(1)
+                        .getTaxPayerFee().intValue()
+        );
+        for (int i = 1; i < gecResponse.getBundleOptions().size() - 2; i++) {
+            assertTrue(
+                    serviceResponse.getBundles().get(i).getTaxPayerFee().intValue() < serviceResponse.getBundles()
+                            .get(i + 1).getTaxPayerFee().intValue()
+            );
+        }
+    }
+
+    @Test
+    void shouldReturnsSortedFeeListPlacingOnUsInFirstAndSecondPositionSortedByFees() {
+        final var paymentMethodId = UUID.randomUUID().toString();
+        final var calculateFeeRequestDto = TestUtil.V2.getMultiNoticeFeesRequest();
+        final var gecResponse = TestUtil.V2.getBundleOptionDtoClientResponseWithUnsortedTransferListTwoOnUs();
+        Mockito.when(paymentMethodRepository.findById(paymentMethodId))
+                .thenReturn(Mono.just(PAYMENT_METHOD_TEST));
+        Mockito.when(afmClient.getFeesForNotices(any(), any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(gecResponse));
+
+        CalculateFeeResponseDto serviceResponse = paymentMethodService
+                .computeFee(calculateFeeRequestDto, paymentMethodId, null).block();
+        assertEquals(gecResponse.getBundleOptions().size(), serviceResponse.getBundles().size());
+        assertEquals(PAYMENT_METHOD_TEST.getPaymentMethodName(), serviceResponse.getPaymentMethodName());
+        assertEquals(
+                PAYMENT_METHOD_TEST.getPaymentMethodDescription(),
+                serviceResponse.getPaymentMethodDescription()
+        );
+        assertTrue(serviceResponse.getBundles().get(0).getOnUs());
+        assertTrue(serviceResponse.getBundles().get(1).getOnUs());
+        assertFalse(serviceResponse.getBundles().get(2).getOnUs());
+        assertFalse(serviceResponse.getBundles().get(3).getOnUs());
+
+        assertTrue(
+                serviceResponse.getBundles().get(0).getTaxPayerFee().intValue() < serviceResponse.getBundles().get(1)
+                        .getTaxPayerFee().intValue()
+        );
+        assertTrue(
+                serviceResponse.getBundles().get(2).getTaxPayerFee().intValue() < serviceResponse.getBundles().get(3)
+                        .getTaxPayerFee().intValue()
+        );
+        assertFalse(
+                serviceResponse.getBundles().get(1).getTaxPayerFee().intValue() < serviceResponse.getBundles().get(2)
+                        .getTaxPayerFee().intValue()
+        );
+    }
+
+    @Test
+    void shouldReturnsSortedFeeListForAllOnUSBundles() {
+        final var paymentMethodId = UUID.randomUUID().toString();
+        final var calculateFeeRequestDto = TestUtil.V2.getMultiNoticeFeesRequest();
+        final var gecResponse = TestUtil.V2.getBundleOptionDtoClientResponseWithUnsortedTransferListAllOnUs();
+        Mockito.when(paymentMethodRepository.findById(paymentMethodId))
+                .thenReturn(Mono.just(PAYMENT_METHOD_TEST));
+        Mockito.when(afmClient.getFeesForNotices(any(), any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(gecResponse));
+
+        CalculateFeeResponseDto serviceResponse = paymentMethodService
+                .computeFee(calculateFeeRequestDto, paymentMethodId, null).block();
+        assertEquals(gecResponse.getBundleOptions().size(), serviceResponse.getBundles().size());
+        assertEquals(PAYMENT_METHOD_TEST.getPaymentMethodName(), serviceResponse.getPaymentMethodName());
+        assertEquals(
+                PAYMENT_METHOD_TEST.getPaymentMethodDescription(),
+                serviceResponse.getPaymentMethodDescription()
+        );
+        for (int i = 0; i < gecResponse.getBundleOptions().size() - 2; i++) {
+            assertTrue(
+                    serviceResponse.getBundles().get(i).getTaxPayerFee().intValue() <= serviceResponse.getBundles()
+                            .get(i + 1).getTaxPayerFee().intValue()
+            );
+        }
+        assertTrue(
+                serviceResponse.getBundles().stream().max(
+                        (
+                         b1,
+                         b2
+                        ) -> (int) (b1.getTaxPayerFee() - b2.getTaxPayerFee())
+                ).get().getTaxPayerFee().equals(
+                        serviceResponse.getBundles().get(gecResponse.getBundleOptions().size() - 1).getTaxPayerFee()
+                )
+        );
+        assertTrue(
+                serviceResponse.getBundles().stream().min(
+                        (
+                         b1,
+                         b2
+                        ) -> (int) (b1.getTaxPayerFee() - b2.getTaxPayerFee())
+                ).get().getTaxPayerFee().equals(serviceResponse.getBundles().get(0).getTaxPayerFee())
+        );
+    }
+
+    @Test
+    void shouldReturnsFeeListMaintainingSortingForOnUsAndNotOnUsBundles() {
+        final var paymentMethodId = UUID.randomUUID().toString();
+        final var calculateFeeRequestDto = TestUtil.V2.getMultiNoticeFeesRequest();
+        final var gecResponse = TestUtil.V2.getBundleOptionDtoClientResponseWithUnsortedTransferMixedWithSameFees();
+        Mockito.when(paymentMethodRepository.findById(paymentMethodId))
+                .thenReturn(Mono.just(PAYMENT_METHOD_TEST));
+        Mockito.when(afmClient.getFeesForNotices(any(), any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(gecResponse));
+
+        CalculateFeeResponseDto serviceResponse = paymentMethodService
+                .computeFee(calculateFeeRequestDto, paymentMethodId, null).block();
+        assertEquals(gecResponse.getBundleOptions().size(), serviceResponse.getBundles().size());
+        assertEquals(PAYMENT_METHOD_TEST.getPaymentMethodName(), serviceResponse.getPaymentMethodName());
+        assertEquals(
+                PAYMENT_METHOD_TEST.getPaymentMethodDescription(),
+                serviceResponse.getPaymentMethodDescription()
+        );
+        assertTrue(serviceResponse.getBundles().get(0).getOnUs());
+        assertTrue(serviceResponse.getBundles().get(1).getOnUs());
+        assertTrue(serviceResponse.getBundles().get(2).getOnUs());
+        assertFalse(serviceResponse.getBundles().get(3).getOnUs());
+        assertFalse(serviceResponse.getBundles().get(4).getOnUs());
+        assertFalse(serviceResponse.getBundles().get(5).getOnUs());
+
+        List<BundleDto> serviceIdPspOnUsList = serviceResponse.getBundles().stream().filter(BundleDto::getOnUs)
+                .toList();
+        List<TransferDto> gecIdPspOnUsList = gecResponse.getBundleOptions().stream().filter(TransferDto::getOnUs)
+                .toList();
+
+        List<BundleDto> serviceIdPspNotOnUsList = serviceResponse.getBundles().stream()
+                .filter(bundleDto -> !bundleDto.getOnUs()).toList();
+        List<TransferDto> gecIdPspNotOnUsList = gecResponse.getBundleOptions().stream()
+                .filter(transferDto -> Boolean.FALSE.equals(transferDto.getOnUs())).toList();
+
+        for (int i = 0; i < serviceIdPspOnUsList.size(); i++) {
+            assertTrue(serviceIdPspOnUsList.get(i).getIdPsp().equals(gecIdPspOnUsList.get(i).getIdPsp()));
+        }
+
+        for (int i = 0; i < serviceIdPspNotOnUsList.size(); i++) {
+            assertTrue(serviceIdPspNotOnUsList.get(i).getIdPsp().equals(gecIdPspNotOnUsList.get(i).getIdPsp()));
+        }
+
+    }
 
     @Test
     void shouldRetrieveFeeForMultiplePaymentNotice() {

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
@@ -158,7 +158,8 @@ class PaymentMethodServiceTests {
 
         boolean samePositionForAllelements = true;
         for (int i = 0; i < serviceIdPspNotOnUsList.size(); i++) {
-            samePositionForAllelements &= serviceIdPspNotOnUsList.get(i).getIdPsp().equals(gecIdPspNotOnUsList.get(i).getIdPsp());
+            samePositionForAllelements &= serviceIdPspNotOnUsList.get(i).getIdPsp()
+                    .equals(gecIdPspNotOnUsList.get(i).getIdPsp());
         }
         assertFalse(samePositionForAllelements);
     }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -518,6 +518,337 @@ public class TestUtil {
                     );
         }
 
+        public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListAllNotOnUs() {
+            List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_1")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest1")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUse")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest2")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TEN.longValue())
+                            .taxPayerFee(BigInteger.TEN.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest3")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.ONE.longValue())
+                            .taxPayerFee(BigInteger.ONE.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+
+            return new it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto()
+                    .belowThreshold(true)
+                    .bundleOptions(
+                            transferList
+                    );
+        }
+
+        public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListOnlyOneOnUs() {
+            List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_1")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest1")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest2")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest3")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TEN.longValue())
+                            .taxPayerFee(BigInteger.TEN.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            return new it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto()
+                    .belowThreshold(true)
+                    .bundleOptions(
+                            transferList
+                    );
+        }
+
+        public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListTwoOnUs() {
+            List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_1")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest1")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest2")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.ONE.longValue())
+                            .taxPayerFee(BigInteger.ONE.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest3")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TEN.longValue())
+                            .taxPayerFee(BigInteger.TEN.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest4")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.ZERO.longValue())
+                            .taxPayerFee(BigInteger.ZERO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            return new it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto()
+                    .belowThreshold(true)
+                    .bundleOptions(
+                            transferList
+                    );
+        }
+
+        public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListAllOnUs() {
+            List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_1")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest1")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest2")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TEN.longValue())
+                            .taxPayerFee(BigInteger.TEN.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_3")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest3")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            return new it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto()
+                    .belowThreshold(true)
+                    .bundleOptions(
+                            transferList
+                    );
+        }
+
+        public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferMixedWithSameFees() {
+            List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_1")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest1")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest2")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest3")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest4")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest5")
+                            .onUs(false)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            transferList.add(
+                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
+                            .bundleDescription("descriptionTest")
+                            .bundleName("bundleNameTest")
+                            .idBrokerPsp("idBrokerPspTest")
+                            .idBundle("idBundleTest")
+                            .idChannel("idChannelTest")
+                            .idPsp("idPspTest6")
+                            .onUs(true)
+                            .paymentMethod("idPaymentMethodTest")
+                            .actualPayerFee(BigInteger.TWO.longValue())
+                            .taxPayerFee(BigInteger.TWO.longValue())
+                            .touchpoint("CHECKOUT")
+                            .fees(List.of())
+            );
+            return new it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto()
+                    .belowThreshold(true)
+                    .bundleOptions(
+                            transferList
+                    );
+        }
+
         public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionWithAnyValueDtoClientResponse() {
             List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
             transferList.add(

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/utils/TestUtil.java
@@ -443,6 +443,190 @@ public class TestUtil {
         return PaymentMethodRequestDto.ClientIdEnum.IO;
     }
 
+    public static it.pagopa.generated.ecommerce.gec.v1.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListAllNotOnUs() {
+        List<it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto> transferList = new ArrayList<>();
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestNotOnUs_1")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest1")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestOnUse")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest2")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TEN.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestNotOnUs_2")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest3")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.ONE.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+
+        return new it.pagopa.generated.ecommerce.gec.v1.dto.BundleOptionDto()
+                .belowThreshold(true)
+                .bundleOptions(
+                        transferList
+                );
+    }
+
+    public static it.pagopa.generated.ecommerce.gec.v1.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListOnlyOneOnUs() {
+        List<it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto> transferList = new ArrayList<>();
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestNotOnUs_1")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest1")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestNotOnUs_2")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest2")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestOnUs")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest3")
+                        .onUs(true)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TEN.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        return new it.pagopa.generated.ecommerce.gec.v1.dto.BundleOptionDto()
+                .belowThreshold(true)
+                .bundleOptions(
+                        transferList
+                );
+    }
+
+    public static it.pagopa.generated.ecommerce.gec.v1.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferMixedWithSameFees() {
+        List<it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto> transferList = new ArrayList<>();
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestOnUs_1")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest1")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestOnUs_2")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest2")
+                        .onUs(true)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestOnUs_2")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest3")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestNotOnUs_2")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest4")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestNotOnUs_2")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest5")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        transferList.add(
+                new it.pagopa.generated.ecommerce.gec.v1.dto.TransferDto().abi("abiTestNotOnUs_2")
+                        .bundleDescription("descriptionTest")
+                        .bundleName("bundleNameTest")
+                        .idBrokerPsp("idBrokerPspTest")
+                        .idBundle("idBundleTest")
+                        .idChannel("idChannelTest")
+                        .idPsp("idPspTest6")
+                        .onUs(false)
+                        .paymentMethod("idPaymentMethodTest")
+                        .taxPayerFee(BigInteger.TWO.longValue())
+                        .touchpoint("CHECKOUT")
+        );
+        return new it.pagopa.generated.ecommerce.gec.v1.dto.BundleOptionDto()
+                .belowThreshold(true)
+                .bundleOptions(
+                        transferList
+                );
+    }
+
     public static class V2 {
         public static it.pagopa.ecommerce.payment.methods.v2.server.model.CalculateFeeRequestDto getMultiNoticeFeesRequest() {
             final var notices = LongStream.of(10L, 20L)
@@ -627,129 +811,6 @@ public class TestUtil {
                     );
         }
 
-        public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListTwoOnUs() {
-            List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
-            transferList.add(
-                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_1")
-                            .bundleDescription("descriptionTest")
-                            .bundleName("bundleNameTest")
-                            .idBrokerPsp("idBrokerPspTest")
-                            .idBundle("idBundleTest")
-                            .idChannel("idChannelTest")
-                            .idPsp("idPspTest1")
-                            .onUs(true)
-                            .paymentMethod("idPaymentMethodTest")
-                            .actualPayerFee(BigInteger.TWO.longValue())
-                            .taxPayerFee(BigInteger.TWO.longValue())
-                            .touchpoint("CHECKOUT")
-                            .fees(List.of())
-            );
-            transferList.add(
-                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_2")
-                            .bundleDescription("descriptionTest")
-                            .bundleName("bundleNameTest")
-                            .idBrokerPsp("idBrokerPspTest")
-                            .idBundle("idBundleTest")
-                            .idChannel("idChannelTest")
-                            .idPsp("idPspTest2")
-                            .onUs(true)
-                            .paymentMethod("idPaymentMethodTest")
-                            .actualPayerFee(BigInteger.ONE.longValue())
-                            .taxPayerFee(BigInteger.ONE.longValue())
-                            .touchpoint("CHECKOUT")
-                            .fees(List.of())
-            );
-            transferList.add(
-                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
-                            .bundleDescription("descriptionTest")
-                            .bundleName("bundleNameTest")
-                            .idBrokerPsp("idBrokerPspTest")
-                            .idBundle("idBundleTest")
-                            .idChannel("idChannelTest")
-                            .idPsp("idPspTest3")
-                            .onUs(false)
-                            .paymentMethod("idPaymentMethodTest")
-                            .actualPayerFee(BigInteger.TEN.longValue())
-                            .taxPayerFee(BigInteger.TEN.longValue())
-                            .touchpoint("CHECKOUT")
-                            .fees(List.of())
-            );
-            transferList.add(
-                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestNotOnUs_2")
-                            .bundleDescription("descriptionTest")
-                            .bundleName("bundleNameTest")
-                            .idBrokerPsp("idBrokerPspTest")
-                            .idBundle("idBundleTest")
-                            .idChannel("idChannelTest")
-                            .idPsp("idPspTest4")
-                            .onUs(false)
-                            .paymentMethod("idPaymentMethodTest")
-                            .actualPayerFee(BigInteger.ZERO.longValue())
-                            .taxPayerFee(BigInteger.ZERO.longValue())
-                            .touchpoint("CHECKOUT")
-                            .fees(List.of())
-            );
-            return new it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto()
-                    .belowThreshold(true)
-                    .bundleOptions(
-                            transferList
-                    );
-        }
-
-        public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferListAllOnUs() {
-            List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
-            transferList.add(
-                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_1")
-                            .bundleDescription("descriptionTest")
-                            .bundleName("bundleNameTest")
-                            .idBrokerPsp("idBrokerPspTest")
-                            .idBundle("idBundleTest")
-                            .idChannel("idChannelTest")
-                            .idPsp("idPspTest1")
-                            .onUs(true)
-                            .paymentMethod("idPaymentMethodTest")
-                            .actualPayerFee(BigInteger.TWO.longValue())
-                            .taxPayerFee(BigInteger.TWO.longValue())
-                            .touchpoint("CHECKOUT")
-                            .fees(List.of())
-            );
-            transferList.add(
-                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_2")
-                            .bundleDescription("descriptionTest")
-                            .bundleName("bundleNameTest")
-                            .idBrokerPsp("idBrokerPspTest")
-                            .idBundle("idBundleTest")
-                            .idChannel("idChannelTest")
-                            .idPsp("idPspTest2")
-                            .onUs(true)
-                            .paymentMethod("idPaymentMethodTest")
-                            .actualPayerFee(BigInteger.TEN.longValue())
-                            .taxPayerFee(BigInteger.TEN.longValue())
-                            .touchpoint("CHECKOUT")
-                            .fees(List.of())
-            );
-            transferList.add(
-                    new it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto().abi("abiTestOnUs_3")
-                            .bundleDescription("descriptionTest")
-                            .bundleName("bundleNameTest")
-                            .idBrokerPsp("idBrokerPspTest")
-                            .idBundle("idBundleTest")
-                            .idChannel("idChannelTest")
-                            .idPsp("idPspTest3")
-                            .onUs(true)
-                            .paymentMethod("idPaymentMethodTest")
-                            .actualPayerFee(BigInteger.TWO.longValue())
-                            .taxPayerFee(BigInteger.TWO.longValue())
-                            .touchpoint("CHECKOUT")
-                            .fees(List.of())
-            );
-            return new it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto()
-                    .belowThreshold(true)
-                    .bundleOptions(
-                            transferList
-                    );
-        }
-
         public static it.pagopa.generated.ecommerce.gec.v2.dto.BundleOptionDto getBundleOptionDtoClientResponseWithUnsortedTransferMixedWithSameFees() {
             List<it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto> transferList = new ArrayList<>();
             transferList.add(
@@ -805,7 +866,7 @@ public class TestUtil {
                             .idBundle("idBundleTest")
                             .idChannel("idChannelTest")
                             .idPsp("idPspTest4")
-                            .onUs(true)
+                            .onUs(false)
                             .paymentMethod("idPaymentMethodTest")
                             .actualPayerFee(BigInteger.TWO.longValue())
                             .taxPayerFee(BigInteger.TWO.longValue())
@@ -835,7 +896,7 @@ public class TestUtil {
                             .idBundle("idBundleTest")
                             .idChannel("idChannelTest")
                             .idPsp("idPspTest6")
-                            .onUs(true)
+                            .onUs(false)
                             .paymentMethod("idPaymentMethodTest")
                             .actualPayerFee(BigInteger.TWO.longValue())
                             .taxPayerFee(BigInteger.TWO.longValue())


### PR DESCRIPTION
Add sorting to psp list returned by afm service.

PSPs are now sorted in this way: the first element of the result list is the onus bundle (if available). Then the psps are sorted by fees from lower to higher. If any set of psps of the same fees exists, its sorting is shuffled.

#### List of Changes

- add sorting as described above, to v1 and v2 api
- add and fix junit tests

#### Motivation and Context

This PR introduce sorting to psps list bypassing afm original sorting

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.