### PR TITLE
[PIDM-44] fix(scheduling): remove EnableScheduling annotation

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/payment/methods/PaymentMethodsApplication.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/PaymentMethodsApplication.java
@@ -7,7 +7,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 @EnableConfigurationProperties(SessionUrlConfig.class)
 public class PaymentMethodsApplication {
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Removed EnableScheduling annotation

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The scheduler was used in the previous version for the service when it fetched the psp list directly from the node, without going through GEC. In the latest version the scheduler is not used anymore therefore the annotation is not necessary anymore.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- mvn validate executed successfully
- mvn clean test executed successfully
- mvn clean verify executed successfully
- mvn spring-boot:run executed successfully

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.