### PR TITLE
feat: [CHK-3775] workload identity and helm chart 7

### DIFF
--- a/.devops/azure-templates/helm-microservice-chart-deploy.yml
+++ b/.devops/azure-templates/helm-microservice-chart-deploy.yml
@@ -56,7 +56,10 @@ steps:
       install: true
       waitForExecution: ${{ parameters.WAIT_FOR_EXECUTION }}
       arguments: ${{ parameters.ARGUMENTS }}
-      overrideValues: microservice-chart.image.tag=${{ parameters.GREEN_VERSION }},microservice-chart.canaryDelivery.create=${{ parameters.DO_BLUE_GREEN_DEPLOY }},microservice-chart.canaryDelivery.deployment.image.tag=${{ parameters.BLUE_VERSION }}
+      ${{ if eq(parameters['DO_BLUE_GREEN_DEPLOY'], True) }}:
+        overrideValues: microservice-chart.image.tag=${{ parameters.GREEN_VERSION }},microservice-chart.canaryDelivery.create=true,microservice-chart.canaryDelivery.image.tag=${{ parameters.BLUE_VERSION }},microservice-chart.fullnameOverride=beta-pagopa-ecommerce-payment-methods-service
+      ${{ else }}:
+        overrideValues: microservice-chart.image.tag=${{ parameters.GREEN_VERSION }},microservice-chart.canaryDelivery.create=false
   - template: ./chart-current-version.yml
   - ${{ if ne(parameters['APPINSIGHTS_SERVICE_CONN'], 'none') }}:
       - task: AzureCLI@2

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -129,7 +129,6 @@ stages:
                 - template: azure-templates/helm-microservice-chart-deploy.yml
                   parameters:
                     DO_DEPLOY: true
-                    DO_BLUE_GREEN_DEPLOY: true
                     ENV: 'DEV'
                     KUBERNETES_SERVICE_CONN: $(DEV_KUBERNETES_SERVICE_CONN)
                     NAMESPACE: ecommerce
@@ -229,7 +228,7 @@ stages:
                     ENV: 'UAT'
                     KUBERNETES_SERVICE_CONN: $(UAT_KUBERNETES_SERVICE_CONN)
                     NAMESPACE: ecommerce
-                    APP_NAME: $(K8S_IMAGE_REPOSITORY_NAME)
+                    APP_NAME: beta-$(K8S_IMAGE_REPOSITORY_NAME)
                     VALUE_FILE: "helm/values-uat.yaml"
                     GREEN_VERSION: $(green_app_version)
                     BLUE_VERSION: $(Build.SourceVersion)
@@ -495,7 +494,7 @@ stages:
                     ENV: 'PROD'
                     KUBERNETES_SERVICE_CONN: $(PROD_KUBERNETES_SERVICE_CONN)
                     NAMESPACE: ecommerce
-                    APP_NAME: $(K8S_IMAGE_REPOSITORY_NAME)
+                    APP_NAME: beta-$(K8S_IMAGE_REPOSITORY_NAME)
                     VALUE_FILE: "helm/values-prod.yaml"
                     GREEN_VERSION: $(app_version)
                     BLUE_VERSION: $(Build.SourceVersion)

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: microservice-chart
   repository: https://pagopa.github.io/aks-microservice-chart-blueprint
-  version: 2.3.1
-digest: sha256:92b42c64847373faa6bf054181be2d7ee61e8b6b6d6a5552bf1479691aa95df3
-generated: "2023-01-31T22:18:51.629215+01:00"
+  version: 7.4.0
+digest: sha256:ba6c74f4d1b23251f9256f33bbc5ac6eaaf586569c0b43e37ad413f6d36ceabe
+generated: "2025-03-07T15:16:45.240278+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.15.2
 appVersion: 1.15.2
 dependencies:
   - name: microservice-chart
-    version: 2.3.1
+    version: 7.4.0
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -5,25 +5,23 @@ microservice-chart:
   canaryDelivery:
     create: true
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopadcommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
-        tag: "latest"
-        pullPolicy: Always
-      envConfig:
-        AFM_URI: "https://api.dev.platform.pagopa.it/afm/calculator-service/v1/fees"
-        AFM_URI_V2: "https://api.dev.platform.pagopa.it/afm/calculator-service/v2/fees"
-        ECS_SERVICE_NAME: pagopa-ecommerce-payment-method-service-blue
-        SESSION_URL_BASEPATH: "https://pagopa-d-checkout-cdn-endpoint.azureedge.net"
-        SESSION_URL_NOTIFICATION_URL: "https://api.dev.platform.pagopa.it/ecommerce/npg/notifications/v1/sessions/{orderId}/outcomes?sessionToken={sessionToken}&deployment=blue"
-      envSecret:
-        AFM_KEY: afm-api-key-blue
+      bluegreen: true
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopadcommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
+      tag: "latest"
+    envConfig:
+      AFM_URI: "https://api.dev.platform.pagopa.it/afm/calculator-service/v1/fees"
+      AFM_URI_V2: "https://api.dev.platform.pagopa.it/afm/calculator-service/v2/fees"
+      ECS_SERVICE_NAME: pagopa-ecommerce-payment-method-service-blue
+      SESSION_URL_BASEPATH: "https://pagopa-d-checkout-cdn-endpoint.azureedge.net"
+      SESSION_URL_NOTIFICATION_URL: "https://api.dev.platform.pagopa.it/ecommerce/npg/notifications/v1/sessions/{orderId}/outcomes?sessionToken={sessionToken}&deployment=blue"
+    envSecret:
+      AFM_KEY: afm-api-key-blue
   image:
     repository: pagopadcommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
     tag: "1.15.2"
@@ -57,8 +55,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -160,3 +158,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 1be61b58-24e2-49c8-b401-89ebd004bf2e

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -3,7 +3,7 @@ microservice-chart:
   nameOverride: ""
   fullnameOverride: ""
   canaryDelivery:
-    create: true
+    create: false
     ingress:
       bluegreen: true
       #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -5,64 +5,19 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopapcommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
-        tag: "latest"
-        pullPolicy: Always
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopapcommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
+      tag: "latest"
     envConfig:
-      MONGO_HOST: pagopa-p-weu-ecommerce-cosmos-account.mongo.cosmos.azure.com
-      MONGO_USERNAME: pagopa-p-weu-ecommerce-cosmos-account
-      MONGO_PORT: "10255"
-      MONGO_SSL_ENABLED: "true"
-      MONGO_MIN_POOL_SIZE: "0"
-      MONGO_MAX_POOL_SIZE: "50"
-      MONGO_MAX_IDLE_TIMEOUT_MS: "600000"
-      MONGO_CONNECTION_TIMEOUT_MS: "2000"
-      MONGO_SOCKET_TIMEOUT_MS: "10000"
-      MONGO_SERVER_SELECTION_TIMEOUT_MS: "2000"
-      MONGO_WAITING_QUEUE_MS: "2000"
-      MONGO_HEARTBEAT_FREQUENCY_MS: "5000"
-      REDIS_PORT: "6380"
-      REDIS_SSL_ENABLED: "true"
-      AFM_URI: "https://api.platform.pagopa.it/afm/calculator-service/v1/fees"
-      AFM_READ_TIMEOUT: "10000"
-      AFM_CONNECTION_TIMEOUT: "10000"
-      SPRING_MAX_IN_MEM_SIZE: "16777216"
       OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-payment-methods-service-blue,deployment.environment=prod"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.elastic-system.svc:4317"
-      OTEL_LOGS_EXPORTER: none
-      OTEL_TRACES_SAMPLER: "always_on"
       ECS_SERVICE_NAME: pagopa-ecommerce-payment-methods-service-blue
-      ECS_SERVICE_ENVIRONMENT: prod
-      NPG_URI: "https://xpay.nexigroup.com/api/phoenix-0.0"
-      NPG_READ_TIMEOUT: "10000"
-      NPG_CONNECTION_TIMEOUT: "10000"
-      SESSION_URL_BASEPATH: "https://checkout.pagopa.it"
-      SESSION_URL_OUTCOME_SUFFIX: "/esito"
-      SESSION_URL_CANCEL_SUFFIX: "/esito"
-      SESSION_URL_NOTIFICATION_URL: "https://api.platform.pagopa.it/ecommerce/npg/notifications/v1/sessions/{orderId}/outcomes?sessionToken={sessionToken}"
-      NPG_SESSIONS_TTL: "900"
-      NPG_NOTIFICATION_JWT_VALIDITY_TIME: "900"
-      WARMUP_PAYMENT_METHOD_ID: "83b5e0c7-2d35-44f4-9e48-a168b84433a1"
-      NPG_SO_KEEPALIVE: "true"
-      NPG_TCP_KEEPIDLE: "30"
-      NPG_TCP_KEEPINTVL: "10"
-      NPG_TCP_KEEPCNT: "5"
-    envSecret:
-      MONGO_PASSWORD: mongo-ecommerce-password
-      REDIS_PASSWORD: redis-ecommerce-access-key
-      REDIS_HOST: redis-ecommerce-hostname
-      AFM_KEY: afm-api-key
-      OTEL_EXPORTER_OTLP_HEADERS: elastic-otel-token-header
-      NPG_API_KEY: npg-api-key
-      NPG_NOTIFICATION_JWT_SECRET: npg-notification-signing-key
+    envSecret: {}
   image:
     repository: pagopapcommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
     tag: "1.15.2"
@@ -96,8 +51,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -202,3 +157,5 @@ microservice-chart:
                 app.kubernetes.io/instance: pagopaecommercepaymentmethodsservice
             namespaces: ["ecommerce"]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: "d5614882-90dd-47a1-aad1-cdf295201469"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -5,63 +5,19 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopaucommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
-        tag: "latest"
-        pullPolicy: Always
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopaucommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
+      tag: "latest"
     envConfig:
-      MONGO_HOST: pagopa-u-weu-ecommerce-cosmos-account.mongo.cosmos.azure.com
-      MONGO_USERNAME: pagopa-u-weu-ecommerce-cosmos-account
-      MONGO_PORT: "10255"
-      MONGO_SSL_ENABLED: "true"
-      MONGO_MIN_POOL_SIZE: "0"
-      MONGO_MAX_POOL_SIZE: "50"
-      MONGO_MAX_IDLE_TIMEOUT_MS: "600000"
-      MONGO_CONNECTION_TIMEOUT_MS: "2000"
-      MONGO_SOCKET_TIMEOUT_MS: "10000"
-      MONGO_SERVER_SELECTION_TIMEOUT_MS: "2000"
-      MONGO_WAITING_QUEUE_MS: "2000"
-      MONGO_HEARTBEAT_FREQUENCY_MS: "5000"
-      REDIS_PORT: "6380"
-      REDIS_SSL_ENABLED: "true"
-      AFM_URI: "https://api.uat.platform.pagopa.it/afm/calculator-service/v1/fees"
-      AFM_READ_TIMEOUT: "10000"
-      AFM_CONNECTION_TIMEOUT: "10000"
-      SPRING_MAX_IN_MEM_SIZE: "16777216"
       OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-payment-methods-service-blue,deployment.environment=uat"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.elastic-system.svc:4317"
-      OTEL_LOGS_EXPORTER: none
-      OTEL_TRACES_SAMPLER: "always_on"
       ECS_SERVICE_NAME: pagopa-ecommerce-payment-methods-service-blue
-      ECS_SERVICE_ENVIRONMENT: uat
-      NPG_URI: "https://stg-ta.nexigroup.com/api/phoenix-0.0"
-      NPG_READ_TIMEOUT: "10000"
-      NPG_CONNECTION_TIMEOUT: "10000"
-      SESSION_URL_BASEPATH: "https://uat.checkout.pagopa.it"
-      SESSION_URL_OUTCOME_SUFFIX: "/esito"
-      SESSION_URL_CANCEL_SUFFIX: "/esito"
-      SESSION_URL_NOTIFICATION_URL: "https://api.uat.platform.pagopa.it/ecommerce/npg/notifications/v1/sessions/{orderId}/outcomes?sessionToken={sessionToken}"
-      NPG_SESSIONS_TTL: "900"
-      NPG_NOTIFICATION_JWT_VALIDITY_TIME: "900"
-      NPG_SO_KEEPALIVE: "true"
-      NPG_TCP_KEEPIDLE: "5"
-      NPG_TCP_KEEPINTVL: "2"
-      NPG_TCP_KEEPCNT: "10"
-    envSecret:
-      MONGO_PASSWORD: mongo-ecommerce-password
-      REDIS_PASSWORD: redis-ecommerce-access-key
-      REDIS_HOST: redis-ecommerce-hostname
-      AFM_KEY: afm-api-key
-      OTEL_EXPORTER_OTLP_HEADERS: elastic-otel-token-header
-      NPG_API_KEY: npg-api-key
-      NPG_NOTIFICATION_JWT_SECRET: npg-notification-signing-key
+    envSecret: {}
   image:
     repository: pagopaucommonacr.azurecr.io/pagopaecommercepaymentmethodsservice
     tag: "1.15.2"
@@ -95,8 +51,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -192,3 +148,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 449c5b65-f368-487a-881a-b03676420c53


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.3.1 to 7.4.0
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env
- modified the deploy pipeline logic based on the `DO_BLUE_GREEN_DEPLOY` env var
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modification are needed in order to make ecommerce payment methods use workload identities instead of deprecated pod identity.
Also, env variables were cleaned and the deploy pipeline now takes into consideration the blue/green deploy preferences
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
- `--dry-run` diff checkers for blue/green deployments
- Deploy on dev
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
