### PR TITLE
feat: GET NPG order id session transaction id V2

### DIFF
--- a/api-spec/v2/api.yaml
+++ b/api-spec/v2/api.yaml
@@ -66,6 +66,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+  /v2/payment-methods/{id}/sessions/{orderId}/transactionId:
+    get:
+      tags:
+        - payment-methods
+      operationId: getTransactionIdForSession
+      summary: Get eCommerce transaction id for the given NPG session
+      description: API to get a transaction id from a NPG session
+      parameters:
+        - name: id
+          in: path
+          description: Payment Method ID
+          required: true
+          schema:
+            type: string
+        - name: orderId
+          in: path
+          description: Order id related to NPG session
+          required: true
+          schema:
+            type: string
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Session found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionGetTransactionIdResponse'
+        '404':
+          description: Session not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '409':
+          description: Invalid session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '500':
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
 components:
   schemas:
     PaymentNotice:
@@ -229,17 +276,19 @@ components:
         - ENABLED
         - DISABLED
         - INCOMING
-    PaymentMethodManagementType:
-      type: string
-      description: |
-        describes how to manage the payment method authorization flow in wallet and eCommerce domain
-        REDIRECT if it must be managed with a redirect flow, 
-        ONBOARDABLE if it must be managed with NPG and it is possible to save the payment method in the wallet, 
-        NOT_ONBOARDABLE if it must be managed with NPG but the method cannot be saved
-      enum:
-        - REDIRECT
-        - ONBOARDABLE
-        - NOT_ONBOARDABLE
+    SessionGetTransactionIdResponse:
+      type: object
+      description: Transaction id for session successful response
+      properties:
+        transactionId:
+          type: string
+          description: Transaction id associated to this NPG session
+        base64EncodedTransactionId:
+          type: string
+          description: Transaction id associated to this NPG session in base64 encoding
+      required:
+        - transactionId
+        - base64EncodedTransactionId
   requestBodies:
     PostPaymentMethodPSP:
       required: true

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodServiceCommon.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/PaymentMethodServiceCommon.java
@@ -1,0 +1,61 @@
+package it.pagopa.ecommerce.payment.methods.application;
+
+import it.pagopa.ecommerce.commons.domain.TransactionId;
+import it.pagopa.ecommerce.payment.methods.exception.InvalidSessionException;
+import it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException;
+import it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException;
+import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodNotFoundException;
+import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionDocument;
+import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionsTemplateWrapper;
+import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepository;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+public abstract class PaymentMethodServiceCommon {
+
+    private final PaymentMethodRepository paymentMethodRepository;
+    private final NpgSessionsTemplateWrapper npgSessionsTemplateWrapper;
+
+    protected PaymentMethodServiceCommon(
+            PaymentMethodRepository paymentMethodRepository,
+            NpgSessionsTemplateWrapper npgSessionsTemplateWrapper
+    ) {
+        this.paymentMethodRepository = paymentMethodRepository;
+        this.npgSessionsTemplateWrapper = npgSessionsTemplateWrapper;
+    }
+
+    public Mono<TransactionId> isSessionValid(
+                                              String paymentMethodId,
+                                              String orderId,
+                                              String securityToken
+    ) {
+        return paymentMethodRepository
+                .findById(paymentMethodId)
+                .switchIfEmpty(Mono.error(new PaymentMethodNotFoundException(paymentMethodId)))
+                .doOnError(e -> log.info("Error while looking for payment method with id {}: ", paymentMethodId, e))
+                .map(
+                        ignore -> npgSessionsTemplateWrapper.findById(orderId)
+                )
+                .doOnNext(doc -> log.info("Found session for order id {}: {}", orderId, doc.isPresent()))
+                .flatMap(doc -> doc.map(Mono::just).orElse(Mono.error(new OrderIdNotFoundException(orderId))))
+                .flatMap(doc -> {
+                    String transactionId = doc.transactionId();
+                    if (transactionId == null) {
+                        return Mono.error(new InvalidSessionException(orderId));
+                    } else {
+                        return Mono.just(doc);
+                    }
+                })
+                .flatMap(doc -> {
+                    if (!doc.securityToken().equals(securityToken)) {
+                        log.warn("Invalid security token for requested order id {}", orderId);
+                        return Mono.error(new MismatchedSecurityTokenException(orderId, doc.transactionId()));
+                    } else {
+                        return Mono.just(doc);
+                    }
+                })
+                .mapNotNull(NpgSessionDocument::transactionId)
+                .map(TransactionId::new);
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/v1/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/v1/PaymentMethodService.java
@@ -501,10 +501,10 @@ public class PaymentMethodService {
                 );
     }
 
-    public Mono<String> isSessionValid(
-                                       String paymentMethodId,
-                                       String orderId,
-                                       String securityToken
+    public Mono<TransactionId> isSessionValid(
+                                              String paymentMethodId,
+                                              String orderId,
+                                              String securityToken
     ) {
         return paymentMethodRepository
                 .findById(paymentMethodId)
@@ -532,8 +532,7 @@ public class PaymentMethodService {
                     }
                 })
                 .mapNotNull(NpgSessionDocument::transactionId)
-                .map(TransactionId::new)
-                .map(TransactionId::base64);
+                .map(TransactionId::new);
     }
 
     public Mono<NpgSessionDocument> updateSession(

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/v1/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/v1/PaymentMethodService.java
@@ -2,17 +2,20 @@ package it.pagopa.ecommerce.payment.methods.application.v1;
 
 import it.pagopa.ecommerce.commons.client.NpgClient;
 import it.pagopa.ecommerce.commons.domain.Claims;
-import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.generated.npg.v1.dto.FieldsDto;
 import it.pagopa.ecommerce.commons.utils.JwtTokenUtils;
 import it.pagopa.ecommerce.commons.utils.UniqueIdUtils;
 import it.pagopa.ecommerce.payment.methods.application.BundleOptions;
+import it.pagopa.ecommerce.payment.methods.application.PaymentMethodServiceCommon;
 import it.pagopa.ecommerce.payment.methods.client.AfmClient;
 import it.pagopa.ecommerce.payment.methods.config.SessionUrlConfig;
 import it.pagopa.ecommerce.payment.methods.domain.aggregates.PaymentMethod;
 import it.pagopa.ecommerce.payment.methods.domain.aggregates.PaymentMethodFactory;
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.*;
-import it.pagopa.ecommerce.payment.methods.exception.*;
+import it.pagopa.ecommerce.payment.methods.exception.NoBundleFoundException;
+import it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException;
+import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodNotFoundException;
+import it.pagopa.ecommerce.payment.methods.exception.SessionAlreadyAssociatedToTransaction;
 import it.pagopa.ecommerce.payment.methods.infrastructure.*;
 import it.pagopa.ecommerce.payment.methods.server.model.*;
 import it.pagopa.ecommerce.payment.methods.utils.ApplicationService;
@@ -39,7 +42,7 @@ import java.util.stream.Collectors;
 @Service(PaymentMethodService.QUALIFIER_NAME)
 @ApplicationService
 @Slf4j
-public class PaymentMethodService {
+public class PaymentMethodService extends PaymentMethodServiceCommon {
 
     protected static final String QUALIFIER_NAME = "paymentMethodService";
 
@@ -99,6 +102,7 @@ public class PaymentMethodService {
             @Value("${npg.notification.jwt.validity.time}") int npgNotificationTokenValidityTime,
             JwtTokenUtils jwtTokenUtils
     ) {
+        super(paymentMethodRepository, npgSessionsTemplateWrapper);
         this.afmClient = afmClient;
         this.npgClient = npgClient;
         this.paymentMethodFactory = paymentMethodFactory;
@@ -499,40 +503,6 @@ public class PaymentMethodService {
                                 Mono.error(new OrderIdNotFoundException(orderId))
                         )
                 );
-    }
-
-    public Mono<TransactionId> isSessionValid(
-                                              String paymentMethodId,
-                                              String orderId,
-                                              String securityToken
-    ) {
-        return paymentMethodRepository
-                .findById(paymentMethodId)
-                .switchIfEmpty(Mono.error(new PaymentMethodNotFoundException(paymentMethodId)))
-                .doOnError(e -> log.info("Error while looking for payment method with id {}: ", paymentMethodId, e))
-                .map(
-                        ignore -> npgSessionsTemplateWrapper.findById(orderId)
-                )
-                .doOnNext(doc -> log.info("Found session for order id {}: {}", orderId, doc.isPresent()))
-                .flatMap(doc -> doc.map(Mono::just).orElse(Mono.error(new OrderIdNotFoundException(orderId))))
-                .flatMap(doc -> {
-                    String transactionId = doc.transactionId();
-                    if (transactionId == null) {
-                        return Mono.error(new InvalidSessionException(orderId));
-                    } else {
-                        return Mono.just(doc);
-                    }
-                })
-                .flatMap(doc -> {
-                    if (!doc.securityToken().equals(securityToken)) {
-                        log.warn("Invalid security token for requested order id {}", orderId);
-                        return Mono.error(new MismatchedSecurityTokenException(orderId, doc.transactionId()));
-                    } else {
-                        return Mono.just(doc);
-                    }
-                })
-                .mapNotNull(NpgSessionDocument::transactionId)
-                .map(TransactionId::new);
     }
 
     public Mono<NpgSessionDocument> updateSession(

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/application/v2/PaymentMethodService.java
@@ -2,33 +2,30 @@ package it.pagopa.ecommerce.payment.methods.application.v2;
 
 import io.vavr.Tuple;
 import it.pagopa.ecommerce.payment.methods.application.BundleOptions;
+import it.pagopa.ecommerce.payment.methods.application.PaymentMethodServiceCommon;
 import it.pagopa.ecommerce.payment.methods.client.AfmClient;
 import it.pagopa.ecommerce.payment.methods.exception.NoBundleFoundException;
 import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodNotFoundException;
+import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionsTemplateWrapper;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodDocument;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepository;
 import it.pagopa.ecommerce.payment.methods.utils.ApplicationService;
-import it.pagopa.ecommerce.payment.methods.v2.server.model.BundleDto;
-import it.pagopa.ecommerce.payment.methods.v2.server.model.CalculateFeeRequestDto;
-import it.pagopa.ecommerce.payment.methods.v2.server.model.CalculateFeeResponseDto;
-import it.pagopa.ecommerce.payment.methods.v2.server.model.PaymentMethodStatusDto;
-import it.pagopa.ecommerce.payment.methods.v2.server.model.PaymentNoticeDto;
+import it.pagopa.ecommerce.payment.methods.v2.server.model.*;
 import it.pagopa.generated.ecommerce.gec.v2.dto.PaymentNoticeItemDto;
 import it.pagopa.generated.ecommerce.gec.v2.dto.PaymentOptionMultiDto;
 import it.pagopa.generated.ecommerce.gec.v2.dto.PspSearchCriteriaDto;
 import it.pagopa.generated.ecommerce.gec.v2.dto.TransferListItemDto;
-
-import java.util.*;
-import java.util.function.Predicate;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.util.*;
+import java.util.function.Predicate;
+
 @Service(PaymentMethodService.QUALIFIER_NAME)
 @ApplicationService
 @Slf4j
-public class PaymentMethodService {
+public class PaymentMethodService extends PaymentMethodServiceCommon {
 
     protected static final String QUALIFIER_NAME = "paymentMethodServiceV2";
 
@@ -37,8 +34,10 @@ public class PaymentMethodService {
 
     public PaymentMethodService(
             PaymentMethodRepository paymentMethodRepository,
-            AfmClient afmClient
+            AfmClient afmClient,
+            NpgSessionsTemplateWrapper npgSessionsTemplateWrapper
     ) {
+        super(paymentMethodRepository, npgSessionsTemplateWrapper);
         this.paymentMethodRepository = paymentMethodRepository;
         this.afmClient = afmClient;
     }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsController.java
@@ -24,10 +24,10 @@ import javax.validation.Valid;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static it.pagopa.ecommerce.payment.methods.utils.HttpUtils.getAuthenticationToken;
 
 @RestController
 @Slf4j
@@ -287,21 +287,6 @@ public class PaymentMethodsController implements PaymentMethodsApi {
         return patchSessionRequestDto
                 .flatMap(updateData -> paymentMethodService.updateSession(id, orderId, updateData))
                 .map(ignored -> ResponseEntity.noContent().build());
-    }
-
-    private Mono<String> getAuthenticationToken(ServerWebExchange exchange) {
-        return Mono.justOrEmpty(
-                Optional.ofNullable(
-                        exchange.getRequest()
-                                .getHeaders()
-                                .get("Authorization")
-                )
-                        .orElse(List.of())
-                        .stream()
-                        .findFirst()
-                        .filter(header -> header.startsWith("Bearer "))
-                        .map(header -> header.substring("Bearer ".length()))
-        );
     }
 
     @Warmup

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsController.java
@@ -1,7 +1,6 @@
 package it.pagopa.ecommerce.payment.methods.controller.v1;
 
 import it.pagopa.ecommerce.commons.annotations.Warmup;
-import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.exceptions.JWTTokenGenerationException;
 import it.pagopa.ecommerce.commons.exceptions.NpgResponseException;
 import it.pagopa.ecommerce.payment.methods.application.v1.PaymentMethodService;
@@ -265,16 +264,6 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                                                                                String orderId,
                                                                                                ServerWebExchange exchange
     ) {
-        return getTransactionIdAssociatedToNpgSession(id, orderId, exchange)
-                .map(transactionId -> new SessionGetTransactionIdResponseDto().transactionId(transactionId.base64()))
-                .map(ResponseEntity::ok);
-    }
-
-    public Mono<TransactionId> getTransactionIdAssociatedToNpgSession(
-                                                                      String id,
-                                                                      String orderId,
-                                                                      ServerWebExchange exchange
-    ) {
         return getAuthenticationToken(exchange)
                 .doOnNext(
                         req -> log.info(
@@ -283,7 +272,9 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                 orderId
                         )
                 )
-                .flatMap(securityToken -> paymentMethodService.isSessionValid(id, orderId, securityToken));
+                .flatMap(securityToken -> paymentMethodService.isSessionValid(id, orderId, securityToken))
+                .map(transactionId -> new SessionGetTransactionIdResponseDto().transactionId(transactionId.base64()))
+                .map(ResponseEntity::ok);
     }
 
     @Override

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsController.java
@@ -1,6 +1,7 @@
 package it.pagopa.ecommerce.payment.methods.controller.v1;
 
 import it.pagopa.ecommerce.commons.annotations.Warmup;
+import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.exceptions.JWTTokenGenerationException;
 import it.pagopa.ecommerce.commons.exceptions.NpgResponseException;
 import it.pagopa.ecommerce.payment.methods.application.v1.PaymentMethodService;
@@ -264,6 +265,16 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                                                                                String orderId,
                                                                                                ServerWebExchange exchange
     ) {
+        return getTransactionIdAssociatedToNpgSession(id, orderId, exchange)
+                .map(transactionId -> new SessionGetTransactionIdResponseDto().transactionId(transactionId.base64()))
+                .map(ResponseEntity::ok);
+    }
+
+    public Mono<TransactionId> getTransactionIdAssociatedToNpgSession(
+                                                                      String id,
+                                                                      String orderId,
+                                                                      ServerWebExchange exchange
+    ) {
         return getAuthenticationToken(exchange)
                 .doOnNext(
                         req -> log.info(
@@ -272,9 +283,7 @@ public class PaymentMethodsController implements PaymentMethodsApi {
                                 orderId
                         )
                 )
-                .flatMap(securityToken -> paymentMethodService.isSessionValid(id, orderId, securityToken))
-                .map(transactionId -> new SessionGetTransactionIdResponseDto().transactionId(transactionId))
-                .map(ResponseEntity::ok);
+                .flatMap(securityToken -> paymentMethodService.isSessionValid(id, orderId, securityToken));
     }
 
     @Override

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsController.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsController.java
@@ -20,8 +20,8 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
+
+import static it.pagopa.ecommerce.payment.methods.utils.HttpUtils.getAuthenticationToken;
 
 @RestController("paymentMethodsControllerV2")
 @Slf4j
@@ -139,21 +139,6 @@ public class PaymentMethodsController implements V2Api {
                 .retrieve()
                 .toBodilessEntity()
                 .block(Duration.ofSeconds(30));
-    }
-
-    private Mono<String> getAuthenticationToken(ServerWebExchange exchange) {
-        return Mono.justOrEmpty(
-                Optional.ofNullable(
-                        exchange.getRequest()
-                                .getHeaders()
-                                .get("Authorization")
-                )
-                        .orElse(List.of())
-                        .stream()
-                        .findFirst()
-                        .filter(header -> header.startsWith("Bearer "))
-                        .map(header -> header.substring("Bearer ".length()))
-        );
     }
 
 }

--- a/src/main/java/it/pagopa/ecommerce/payment/methods/utils/HttpUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/payment/methods/utils/HttpUtils.java
@@ -1,0 +1,25 @@
+package it.pagopa.ecommerce.payment.methods.utils;
+
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+public class HttpUtils {
+
+    public static Mono<String> getAuthenticationToken(ServerWebExchange exchange) {
+        return Mono.justOrEmpty(
+                Optional.ofNullable(
+                        exchange.getRequest()
+                                .getHeaders()
+                                .get("Authorization")
+                )
+                        .orElse(List.of())
+                        .stream()
+                        .findFirst()
+                        .filter(header -> header.startsWith("Bearer "))
+                        .map(header -> header.substring("Bearer ".length()))
+        );
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsControllerTests.java
@@ -4,7 +4,6 @@ import io.opentelemetry.api.trace.Tracer;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.exceptions.JWTTokenGenerationException;
 import it.pagopa.ecommerce.commons.exceptions.NpgResponseException;
-import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.ecommerce.payment.methods.application.v1.PaymentMethodService;
 import it.pagopa.ecommerce.payment.methods.domain.aggregates.PaymentMethod;
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodName;
@@ -485,7 +484,7 @@ class PaymentMethodsControllerTests {
         String paymentMethodId = UUID.randomUUID().toString();
         String orderId = "orderId";
         String securityToken = "securityToken";
-        TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);
+        TransactionId transactionId = new TransactionId(UUID.randomUUID());
 
         Mockito.when(paymentMethodService.isSessionValid(paymentMethodId, orderId, securityToken))
                 .thenReturn(Mono.just(transactionId));

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v1/PaymentMethodsControllerTests.java
@@ -1,34 +1,18 @@
 package it.pagopa.ecommerce.payment.methods.controller.v1;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-
 import io.opentelemetry.api.trace.Tracer;
+import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.exceptions.JWTTokenGenerationException;
 import it.pagopa.ecommerce.commons.exceptions.NpgResponseException;
+import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.ecommerce.payment.methods.application.v1.PaymentMethodService;
 import it.pagopa.ecommerce.payment.methods.domain.aggregates.PaymentMethod;
 import it.pagopa.ecommerce.payment.methods.domain.valueobjects.PaymentMethodName;
 import it.pagopa.ecommerce.payment.methods.exception.*;
 import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionDocument;
-import it.pagopa.ecommerce.payment.methods.server.model.CalculateFeeRequestDto;
-import it.pagopa.ecommerce.payment.methods.server.model.CalculateFeeResponseDto;
-import it.pagopa.ecommerce.payment.methods.server.model.CreateSessionResponseDto;
-import it.pagopa.ecommerce.payment.methods.server.model.PatchSessionRequestDto;
-import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodRequestDto;
-import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodResponseDto;
-import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodStatusDto;
-import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodsResponseDto;
-import it.pagopa.ecommerce.payment.methods.server.model.ProblemJsonDto;
-import it.pagopa.ecommerce.payment.methods.server.model.SessionGetTransactionIdResponseDto;
-import it.pagopa.ecommerce.payment.methods.server.model.SessionPaymentMethodResponseDto;
+import it.pagopa.ecommerce.payment.methods.server.model.*;
 import it.pagopa.ecommerce.payment.methods.utils.PaymentMethodStatusEnum;
 import it.pagopa.ecommerce.payment.methods.utils.TestUtil;
-
-import java.util.*;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -44,6 +28,13 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(SpringExtension.class)
 @WebFluxTest(PaymentMethodsController.class)
@@ -494,13 +485,13 @@ class PaymentMethodsControllerTests {
         String paymentMethodId = UUID.randomUUID().toString();
         String orderId = "orderId";
         String securityToken = "securityToken";
-        String transactionId = "transactionId";
+        TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);
 
         Mockito.when(paymentMethodService.isSessionValid(paymentMethodId, orderId, securityToken))
                 .thenReturn(Mono.just(transactionId));
 
         SessionGetTransactionIdResponseDto expected = new SessionGetTransactionIdResponseDto()
-                .transactionId(transactionId);
+                .transactionId(transactionId.base64());
         webClient
                 .get()
                 .uri(

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsControllerTests.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -42,9 +41,6 @@ class PaymentMethodsControllerTests {
 
     @MockBean
     private PaymentMethodService paymentMethodService;
-
-    @MockBean
-    private it.pagopa.ecommerce.payment.methods.controller.v1.PaymentMethodsController paymentMethodsControllerV1;
 
     @InjectMocks
     private PaymentMethodsController paymentMethodsController;
@@ -145,7 +141,7 @@ class PaymentMethodsControllerTests {
         String securityToken = "securityToken";
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
 
-        Mockito.when(paymentMethodsControllerV1.getTransactionIdAssociatedToNpgSession(any(), any(), any()))
+        Mockito.when(paymentMethodService.isSessionValid(any(), any(), any()))
                 .thenReturn(Mono.just(transactionId));
 
         SessionGetTransactionIdResponseDto expected = new SessionGetTransactionIdResponseDto()
@@ -164,8 +160,8 @@ class PaymentMethodsControllerTests {
                 .isOk()
                 .expectBody(SessionGetTransactionIdResponseDto.class)
                 .isEqualTo(expected);
-        verify(paymentMethodsControllerV1, times(1))
-                .getTransactionIdAssociatedToNpgSession(eq(paymentMethodId), eq(orderId), any());
+        verify(paymentMethodService, times(1))
+                .isSessionValid(paymentMethodId, orderId, securityToken);
     }
 
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsControllerTests.java
@@ -2,7 +2,6 @@ package it.pagopa.ecommerce.payment.methods.controller.v2;
 
 import io.opentelemetry.api.trace.Tracer;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
-import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.ecommerce.payment.methods.application.v2.PaymentMethodService;
 import it.pagopa.ecommerce.payment.methods.exception.AfmResponseException;
 import it.pagopa.ecommerce.payment.methods.exception.NoBundleFoundException;
@@ -144,7 +143,7 @@ class PaymentMethodsControllerTests {
         String paymentMethodId = UUID.randomUUID().toString();
         String orderId = "orderId";
         String securityToken = "securityToken";
-        TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);
+        TransactionId transactionId = new TransactionId(UUID.randomUUID());
 
         Mockito.when(paymentMethodsControllerV1.getTransactionIdAssociatedToNpgSession(any(), any(), any()))
                 .thenReturn(Mono.just(transactionId));

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsControllerTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/controller/v2/PaymentMethodsControllerTests.java
@@ -1,9 +1,8 @@
 package it.pagopa.ecommerce.payment.methods.controller.v2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-
 import io.opentelemetry.api.trace.Tracer;
+import it.pagopa.ecommerce.commons.domain.TransactionId;
+import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.ecommerce.payment.methods.application.v2.PaymentMethodService;
 import it.pagopa.ecommerce.payment.methods.exception.AfmResponseException;
 import it.pagopa.ecommerce.payment.methods.exception.NoBundleFoundException;
@@ -12,8 +11,7 @@ import it.pagopa.ecommerce.payment.methods.server.model.ProblemJsonDto;
 import it.pagopa.ecommerce.payment.methods.utils.TestUtil;
 import it.pagopa.ecommerce.payment.methods.v2.server.model.CalculateFeeRequestDto;
 import it.pagopa.ecommerce.payment.methods.v2.server.model.CalculateFeeResponseDto;
-import java.util.List;
-import java.util.UUID;
+import it.pagopa.ecommerce.payment.methods.v2.server.model.SessionGetTransactionIdResponseDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,6 +27,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 @ExtendWith(SpringExtension.class)
 @WebFluxTest(it.pagopa.ecommerce.payment.methods.controller.v2.PaymentMethodsController.class)
 @TestPropertySource(locations = "classpath:application.test.properties")
@@ -36,6 +43,9 @@ class PaymentMethodsControllerTests {
 
     @MockBean
     private PaymentMethodService paymentMethodService;
+
+    @MockBean
+    private it.pagopa.ecommerce.payment.methods.controller.v1.PaymentMethodsController paymentMethodsControllerV1;
 
     @InjectMocks
     private PaymentMethodsController paymentMethodsController;
@@ -128,4 +138,35 @@ class PaymentMethodsControllerTests {
         assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
         assertEquals("reason test", responseEntity.getBody().getDetail());
     }
+
+    @Test
+    void shouldReturnTransactionIdForValidSession() {
+        String paymentMethodId = UUID.randomUUID().toString();
+        String orderId = "orderId";
+        String securityToken = "securityToken";
+        TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);
+
+        Mockito.when(paymentMethodsControllerV1.getTransactionIdAssociatedToNpgSession(any(), any(), any()))
+                .thenReturn(Mono.just(transactionId));
+
+        SessionGetTransactionIdResponseDto expected = new SessionGetTransactionIdResponseDto()
+                .base64EncodedTransactionId(transactionId.base64())
+                .transactionId(transactionId.value());
+        webClient
+                .get()
+                .uri(
+                        builder -> builder
+                                .path("/v2/payment-methods/{paymentMethodId}/sessions/{orderId}/transactionId")
+                                .build(paymentMethodId, orderId)
+                )
+                .headers(h -> h.setBearerAuth(securityToken))
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(SessionGetTransactionIdResponseDto.class)
+                .isEqualTo(expected);
+        verify(paymentMethodsControllerV1, times(1))
+                .getTransactionIdAssociatedToNpgSession(eq(paymentMethodId), eq(orderId), any());
+    }
+
 }

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/v1/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/v1/PaymentMethodServiceTests.java
@@ -44,12 +44,16 @@ import reactor.test.StepVerifier;
 
 import javax.crypto.SecretKey;
 import java.net.URI;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.mongodb.assertions.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -591,7 +595,6 @@ class PaymentMethodServiceTests {
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
         NpgSessionDocument npgSessionDocument = TestUtil
                 .npgSessionDocument("orderId", correlationId, "sessionId", false, transactionId.value());
-        String encodedTransactionId = transactionId.base64();
 
         Mockito.when(paymentMethodRepository.findById(paymentMethodId))
                 .thenReturn(Mono.just(TestUtil.getTestPaymentDoc(paymentMethod)));
@@ -605,7 +608,7 @@ class PaymentMethodServiceTests {
                                 npgSessionDocument.securityToken()
                         )
                 )
-                .expectNext(encodedTransactionId)
+                .expectNext(transactionId)
                 .verifyComplete();
     }
 

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
@@ -1,27 +1,18 @@
 package it.pagopa.ecommerce.payment.methods.service.v2;
 
-import static com.mongodb.assertions.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-
 import it.pagopa.ecommerce.commons.client.NpgClient;
 import it.pagopa.ecommerce.payment.methods.application.v2.PaymentMethodService;
 import it.pagopa.ecommerce.payment.methods.client.AfmClient;
 import it.pagopa.ecommerce.payment.methods.exception.NoBundleFoundException;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodDocument;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepository;
+import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodManagementTypeDto;
 import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodRequestDto;
 import it.pagopa.ecommerce.payment.methods.utils.PaymentMethodStatusEnum;
 import it.pagopa.ecommerce.payment.methods.utils.TestUtil;
 import it.pagopa.ecommerce.payment.methods.v2.server.model.BundleDto;
 import it.pagopa.ecommerce.payment.methods.v2.server.model.CalculateFeeResponseDto;
-import it.pagopa.ecommerce.payment.methods.v2.server.model.PaymentMethodManagementTypeDto;
 import it.pagopa.generated.ecommerce.gec.v2.dto.TransferDto;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,6 +21,16 @@ import org.mockito.Mockito;
 import org.springframework.data.util.Pair;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.mongodb.assertions.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 
 class PaymentMethodServiceTests {
 

--- a/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
+++ b/src/test/java/it/pagopa/ecommerce/payment/methods/service/v2/PaymentMethodServiceTests.java
@@ -4,6 +4,7 @@ import it.pagopa.ecommerce.commons.client.NpgClient;
 import it.pagopa.ecommerce.payment.methods.application.v2.PaymentMethodService;
 import it.pagopa.ecommerce.payment.methods.client.AfmClient;
 import it.pagopa.ecommerce.payment.methods.exception.NoBundleFoundException;
+import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionsTemplateWrapper;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodDocument;
 import it.pagopa.ecommerce.payment.methods.infrastructure.PaymentMethodRepository;
 import it.pagopa.ecommerce.payment.methods.server.model.PaymentMethodManagementTypeDto;
@@ -37,10 +38,12 @@ class PaymentMethodServiceTests {
     private final AfmClient afmClient = mock(AfmClient.class);
 
     private final PaymentMethodRepository paymentMethodRepository = mock(PaymentMethodRepository.class);
+    private final NpgSessionsTemplateWrapper npgSessionsTemplateWrapper = mock(NpgSessionsTemplateWrapper.class);
 
     private final PaymentMethodService paymentMethodService = new PaymentMethodService(
             paymentMethodRepository,
-            afmClient
+            afmClient,
+            npgSessionsTemplateWrapper
     );
 
     @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Create POST `/payment-methods/{id}/sessions/{orderId}/transactionId` V2 api that will return both base 64 and plain transactionId value
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to dismantle all api that use transaction id base64 encoded
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
test in dev env
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.